### PR TITLE
Adding Support for Affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 druid-operator is a kubernetes operator for deploying Druid clusters. It is built using the [operator-sdk](https://github.com/operator-framework/operator-sdk/tree/v0.11.0) . 
 
+# How to run druid-operator locally
+```
+druid-operator$ kubectl create -f deploy/service_account.yaml
+# Setup RBAC
+druid-operator$ kubectl create -f deploy/role.yaml
+druid-operator$ kubectl create -f deploy/role_binding.yaml
+# Setup the CRD
+druid-operator$ kubectl create -f deploy/crds/druid.apache.org_druids_crd.yaml
+# Run operator locally, by default operator shall look for current context in the kubeconfig
+druid-operator$ operator-sdk up local
+```
+
 # How to build druid-operator docker image
 
 Pre-built docker images are available in [DockerHub](https://hub.docker.com/r/druidio/druid-operator). You can build docker image from source code using the command below.

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -149,6 +149,12 @@ type DruidNodeSpec struct {
 	// Optional: Overrides services at top level
 	Services []v1.Service `json:"services,omitempty"`
 
+	// Optional: toleration to be used in order to run Druid on nodes tainted
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+
+	// Optional: affinity to be used to for enabling node, pod affinity and anti-affinity
+	Affinity *v1.Affinity `json:"affinity,omitempty"`
+
 	// Optional: extra ports to be added to pod spec
 	Ports []v1.ContainerPort `json:"ports,omitempty"`
 

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -94,6 +94,8 @@ type DruidClusterSpec struct {
 	// Optional: toleration to be used in order to run Druid on nodes tainted
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 
+	// Optional: affinity to be used to for enabling node, pod affinity and anti-affinity
+	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// Spec used to create StatefulSet specs etc, Many of the fields above can be overridden at the specific
 	// node spec level.
 

--- a/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -134,6 +134,18 @@ func (in *DruidClusterSpec) DeepCopyInto(out *DruidClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
 		*out = make(map[string]DruidNodeSpec, len(*in))

--- a/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -331,6 +331,18 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -595,6 +595,7 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 				Spec: v1.PodSpec{
 					NodeSelector: m.Spec.NodeSelector,
 					Tolerations:  m.Spec.Tolerations,
+					Affinity:     m.Spec.Affinity,
 					Containers: []v1.Container{
 						{
 							Image:          firstNonEmptyStr(nodeSpec.Image, m.Spec.Image),

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -43,14 +43,14 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 	}
 
 	if err := verifyDruidSpec(m); err != nil {
-		e := fmt.Errorf("Invalid DruidSpec[%s:%s] due to [%s].", m.Kind, m.Name, err.Error())
+		e := fmt.Errorf("invalid DruidSpec[%s:%s] due to [%s]", m.Kind, m.Name, err.Error())
 		sendEvent(sdk, m, v1.EventTypeWarning, "SPEC_INVALID", e.Error())
 		return nil
 	}
 
 	allNodeSpecs, err := getAllNodeSpecsInDruidPrescribedOrder(m)
 	if err != nil {
-		e := fmt.Errorf("Invalid DruidSpec[%s:%s] due to [%s].", m.Kind, m.Name, err.Error())
+		e := fmt.Errorf("invalid DruidSpec[%s:%s] due to [%s]", m.Kind, m.Name, err.Error())
 		sendEvent(sdk, m, v1.EventTypeWarning, "SPEC_INVALID", e.Error())
 		return nil
 	}
@@ -211,7 +211,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 	}
 
 	if err := sdk.List(context.TODO(), podList, listOpts...); err != nil {
-		e := fmt.Errorf("Failed to list pods for [%s:%s] due to [%s].", m.Kind, m.Name, err.Error())
+		e := fmt.Errorf("failed to list pods for [%s:%s] due to [%s]", m.Kind, m.Name, err.Error())
 		sendEvent(sdk, m, v1.EventTypeWarning, "LIST_FAIL", e.Error())
 		logger.Error(e, e.Error(), "name", m.Name, "namespace", m.Namespace)
 	}
@@ -224,7 +224,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 			return fmt.Errorf("failed to serialize status patch to bytes: %v", err)
 		}
 		if err := sdk.Patch(context.TODO(), m, client.ConstantPatch(types.MergePatchType, patchBytes)); err != nil {
-			e := fmt.Errorf("Failed to update status for [%s:%s] due to [%s].", m.Kind, m.Name, err.Error())
+			e := fmt.Errorf("failed to update status for [%s:%s] due to [%s]", m.Kind, m.Name, err.Error())
 			sendEvent(sdk, m, v1.EventTypeWarning, "UPDATE_FAIL", e.Error())
 			logger.Error(e, e.Error(), "name", m.Name, "namespace", m.Namespace)
 		}
@@ -245,14 +245,14 @@ func deleteUnusedResources(sdk client.Client, drd *v1alpha1.Druid,
 
 	listObj := emptyListObjFn()
 	if err := sdk.List(context.TODO(), listObj, listOpts...); err != nil {
-		e := fmt.Errorf("Failed to list [%s] due to [%s].", listObj.GetObjectKind().GroupVersionKind().Kind, err.Error())
+		e := fmt.Errorf("failed to list [%s] due to [%s]", listObj.GetObjectKind().GroupVersionKind().Kind, err.Error())
 		sendEvent(sdk, drd, v1.EventTypeWarning, "LIST_FAIL", e.Error())
 		logger.Error(e, e.Error(), "name", drd.Name, "namespace", drd.Namespace)
 	} else {
 		for _, s := range itemsExtractorFn(listObj) {
 			if names[s.GetName()] == false {
-				if err := sdkDelete(sdk, context.TODO(), s); err != nil {
-					e := fmt.Errorf("Failed to delete [%s:%s] due to [%s].", listObj.GetObjectKind().GroupVersionKind().Kind, s.GetName(), err.Error())
+				if err := sdkDelete(context.TODO(), sdk, s); err != nil {
+					e := fmt.Errorf("failed to delete [%s:%s] due to [%s]", listObj.GetObjectKind().GroupVersionKind().Kind, s.GetName(), err.Error())
 					sendEvent(sdk, drd, v1.EventTypeWarning, "DELETE_FAIL", e.Error())
 					logger.Error(e, e.Error(), "name", drd.Name, "namespace", drd.Namespace)
 					survivorNames = append(survivorNames, s.GetName())
@@ -282,11 +282,11 @@ func sdkCreateOrUpdateAsNeeded(sdk client.Client, objFn func() (object, error), 
 		addOwnerRefToObject(obj, asOwner(drd))
 		addHashToObject(obj)
 
-		if err := sdkCreate(sdk, context.TODO(), obj); err != nil {
+		if err := sdkCreate(context.TODO(), sdk, obj); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				prevObj := emptyObjFn()
 				if err := sdk.Get(context.TODO(), *namespacedName(obj.GetName(), obj.GetNamespace()), prevObj); err != nil {
-					e := fmt.Errorf("Failed to get [%s:%s] due to [%s].", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
+					e := fmt.Errorf("failed to get [%s:%s] due to [%s]", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
 					logger.Error(e, e.Error(), "Prev object", stringifyForLogging(prevObj, drd), "name", drd.Name, "namespace", drd.Namespace)
 					sendEvent(sdk, drd, v1.EventTypeWarning, "GET_FAIL", e.Error())
 					return e
@@ -299,7 +299,7 @@ func sdkCreateOrUpdateAsNeeded(sdk client.Client, objFn func() (object, error), 
 						}
 
 						if err := sdk.Update(context.TODO(), obj); err != nil {
-							e := fmt.Errorf("Failed to update [%s:%s] due to [%s].", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
+							e := fmt.Errorf("failed to update [%s:%s] due to [%s]", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
 							logger.Error(e, e.Error(), "Current Object", stringifyForLogging(prevObj, drd), "Updated Object", stringifyForLogging(obj, drd), "name", drd.Name, "namespace", drd.Namespace)
 							sendEvent(sdk, drd, v1.EventTypeWarning, "UPDATE_FAIL", e.Error())
 							return e
@@ -311,7 +311,7 @@ func sdkCreateOrUpdateAsNeeded(sdk client.Client, objFn func() (object, error), 
 					}
 				}
 			} else {
-				e := fmt.Errorf("Failed to create [%s:%s] due to [%s].", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
+				e := fmt.Errorf("failed to create [%s:%s] due to [%s]", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
 				logger.Error(e, e.Error(), "object", stringifyForLogging(obj, drd), "name", drd.Name, "namespace", drd.Namespace)
 				sendEvent(sdk, drd, v1.EventTypeWarning, "CREATE_FAIL", e.Error())
 				return e
@@ -330,7 +330,7 @@ func sdkCreateOrUpdateAsNeeded(sdk client.Client, objFn func() (object, error), 
 func isStsFullyDeployed(sdk client.Client, name string, drd *v1alpha1.Druid) (bool, error) {
 	sts := makeStatefulSetEmptyObj()
 	if err := sdk.Get(context.TODO(), *namespacedName(name, drd.Namespace), sts); err != nil {
-		e := fmt.Errorf("Failed to get [StatefuleSet:%s] due to [%s].", name, err.Error())
+		e := fmt.Errorf("failed to get [StatefuleSet:%s] due to [%s]", name, err.Error())
 		logger.Error(e, e.Error(), "name", drd.Name, "namespace", drd.Namespace)
 		sendEvent(sdk, drd, v1.EventTypeWarning, "GET_FAIL", e.Error())
 		return false, e
@@ -844,7 +844,7 @@ func getAllNodeSpecsInDruidPrescribedOrder(m *v1alpha1.Druid) ([]keyAndNodeSpec,
 	for key, nodeSpec := range m.Spec.Nodes {
 		nodeSpecs := nodeSpecsByNodeType[nodeSpec.NodeType]
 		if nodeSpecs == nil {
-			return nil, fmt.Errorf("DruidSpec[%s:%s] has invalid NodeType[%s]. Deployment aborted.", m.Kind, m.Name, nodeSpec.NodeType)
+			return nil, fmt.Errorf("druidSpec[%s:%s] has invalid NodeType[%s]. Deployment aborted", m.Kind, m.Name, nodeSpec.NodeType)
 		} else {
 			nodeSpecsByNodeType[nodeSpec.NodeType] = append(nodeSpecs, keyAndNodeSpec{key, nodeSpec})
 		}
@@ -882,12 +882,12 @@ func resetGroupVersionKind(obj runtime.Object, gvk schema.GroupVersionKind) {
 }
 
 // Create implements client.Client
-func sdkCreate(sdk client.Client, ctx context.Context, obj runtime.Object) error {
+func sdkCreate(ctx context.Context, sdk client.Client, obj runtime.Object) error {
 	defer resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
 	return sdk.Create(ctx, obj)
 }
 
-func sdkDelete(sdk client.Client, ctx context.Context, obj runtime.Object) error {
+func sdkDelete(ctx context.Context, sdk client.Client, obj runtime.Object) error {
 	defer resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
 	return sdk.Delete(ctx, obj)
 }


### PR DESCRIPTION
Add support for affinity as in case node selectors are removed, we want to run druid pods on same nodes. Plus supporting use cases regarding node, pod anti-affinity.  

Added on how to run operator locally. Can be a pain to each time create image and deploy.