### PR TITLE
sdkCreateOrUpdateAsNeeded(..) to first do get and then create or update as needed

### DIFF
--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -286,7 +286,7 @@ func sdkCreateOrUpdateAsNeeded(sdk client.Client, objFn func() (object, error), 
 		if err := sdk.Get(context.TODO(), *namespacedName(obj.GetName(), obj.GetNamespace()), prevObj); err != nil {
 			if apierrors.IsNotFound(err) {
 				// resource does not exist, create it.
-				if err := sdkCreate(sdk, context.TODO(), obj); err != nil {
+				if err := sdkCreate(context.TODO(), sdk, obj); err != nil {
 					e := fmt.Errorf("Failed to create [%s:%s] due to [%s].", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
 					logger.Error(e, e.Error(), "object", stringifyForLogging(obj, drd), "name", drd.Name, "namespace", drd.Namespace, "errorType", apierrors.ReasonForError(err))
 					sendEvent(sdk, drd, v1.EventTypeWarning, "CREATE_FAIL", e.Error())


### PR DESCRIPTION
Fixes #9 

### Description

Earlier we relied on  ApiExists error on create(..) to discover if a resource already existed, that method proved to be unreliable in case there are custom webhooks employed by k8s cluster operator, doing a GET to explicitly check the existence proved to be more reliable.

Consequently `sdkCreateOrUpdateAsNeeded(..)` in handler.go is updated to reflect above.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.

<hr>

##### Key changed/added files in this PR
 * `handler.go`

