### PR TITLE
ServiceAccount and TerminationGracePeriod

### DIFF
--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+
 	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -9,6 +10,10 @@ import (
 	"k8s.io/api/policy/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DefaultTerminationGracePeriod = 30
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -55,6 +60,9 @@ type DruidClusterSpec struct {
 	// Required: Druid Docker Image
 	Image string `json:"image"`
 
+	// Optional: ServiceAccount for the druid cluster
+	ServiceAccount string `json:"serviceAccount"`
+
 	// Optional: environment variables for druid containers
 	Env []v1.EnvVar `json:"env,omitempty"`
 
@@ -98,6 +106,7 @@ type DruidClusterSpec struct {
 
 	// Optional: affinity to be used to for enabling node, pod affinity and anti-affinity
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
+
 	// Spec used to create StatefulSet specs etc, Many of the fields above can be overridden at the specific
 	// node spec level.
 
@@ -156,6 +165,9 @@ type DruidNodeSpec struct {
 
 	// Optional: affinity to be used to for enabling node, pod affinity and anti-affinity
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
+
+	// Optoinal: terminationGracePeriod defaults to 30 sec.
+	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds"`
 
 	// Optional: extra ports to be added to pod spec
 	Ports []v1.ContainerPort `json:"ports,omitempty"`

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -161,7 +161,7 @@ type DruidNodeSpec struct {
 	// Optional: affinity to be used to for enabling node, pod affinity and anti-affinity
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 
-	// Optional: terminationGracePeriod defaults to 30 sec.
+	// Optional: terminationGracePeriod
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 
 	// Optional: extra ports to be added to pod spec

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -12,10 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	DefaultTerminationGracePeriod = 30
-)
-
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -161,8 +161,8 @@ type DruidNodeSpec struct {
 	// Optional: affinity to be used to for enabling node, pod affinity and anti-affinity
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 
-	// Optoinal: terminationGracePeriod defaults to 30 sec.
-	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds"`
+	// Optional: terminationGracePeriod defaults to 30 sec.
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 
 	// Optional: extra ports to be added to pod spec
 	Ports []v1.ContainerPort `json:"ports,omitempty"`

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -105,7 +105,6 @@ type DruidClusterSpec struct {
 
 	// Spec used to create StatefulSet specs etc, Many of the fields above can be overridden at the specific
 	// node spec level.
-
 	// Key in following map can be arbitrary string that helps you identify resources(pods, statefulsets etc) for specific nodeSpec.
 	// But, it is used in the k8s resource names, so it must be compliant with restrictions
 	// placed on k8s resource names.

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -847,15 +847,6 @@ func makeServiceEmptyObj() *v1.Service {
 	}
 }
 
-func makeServiceAccountEmptyObj() *v1.ServiceAccount {
-	return &v1.ServiceAccount{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ServiceAccount",
-		},
-	}
-}
-
 func makeConfigMapEmptyObj() *v1.ConfigMap {
 	return &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -583,7 +583,6 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 		},
 		{
 			Name: "nodetype-config-volume",
-
 			VolumeSource: v1.VolumeSource{
 				ConfigMap: &v1.ConfigMapVolumeSource{
 					LocalObjectReference: v1.LocalObjectReference{

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -680,7 +680,6 @@ func getTerminationGracePeriod(nodeSpec *v1alpha1.DruidNodeSpec) *int64 {
 
 	if nodeSpec.TerminationGracePeriodSeconds == 0 {
 		nodeSpec.TerminationGracePeriodSeconds = 30
-		//return &clusterSpec.Spec.TerminationGracePeriodSeconds
 	}
 
 	return &nodeSpec.TerminationGracePeriodSeconds

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -656,7 +656,7 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 							ReadinessProbe: readinessProbe,
 						},
 					},
-					TerminationGracePeriodSeconds: getTerminationGracePeriod(nodeSpec),
+					TerminationGracePeriodSeconds: nodeSpec.TerminationGracePeriodSeconds,
 					Volumes:                       volumesHolder,
 					SecurityContext:               firstNonNilValue(nodeSpec.SecurityContext, m.Spec.SecurityContext).(*v1.PodSecurityContext),
 					ServiceAccountName:            m.Spec.ServiceAccount,
@@ -673,15 +673,6 @@ func updateDefaultPortInProbe(probe *v1.Probe, defaultPort int32) *v1.Probe {
 		probe.HTTPGet.Port.IntVal = defaultPort
 	}
 	return probe
-}
-
-func getTerminationGracePeriod(nodeSpec *v1alpha1.DruidNodeSpec) *int64 {
-
-	if nodeSpec.TerminationGracePeriodSeconds == 0 {
-		nodeSpec.TerminationGracePeriodSeconds = 30
-	}
-
-	return &nodeSpec.TerminationGracePeriodSeconds
 }
 
 func makePodDisruptionBudget(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[string]string, nodeSpecUniqueStr string) (*v1beta1.PodDisruptionBudget, error) {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #10 
Fixes #24 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
TerminationGrace Period is limited to 30sec as default. Some processes such as middle managers, historicals needs more graceful time during an update.
ServiceAccount, deploys the cluster in a specified SA, helps in giving access, applying RBACs to druid cluster across a cluster
<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->
- This func returns the TGP if defined else keeps is too 30. When directly using TGP without the func k8s keeps the sts TGP to 0. 
```
func getTerminationGracePeriod(nodeSpec *v1alpha1.DruidNodeSpec) 
```
<hr>

This PR has:
- [x ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * ```handler.go```
 * ```druid_types.go```
