### PR TITLE
add imagePullSecrets to druid spec

### DIFF
--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -4,6 +4,9 @@ metadata:
   name: tiny-cluster
 spec:
   image: apache/incubator-druid:0.16.0-incubating
+  # Optionally specify image for all nodes. Can be specify on nodes also
+  # imagePullSecrets:
+  # - name: tutu
   startScript: /druid.sh
   securityContext:
     fsGroup: 1000
@@ -67,6 +70,9 @@ spec:
   nodes:
     brokers:
       nodeType: "broker"
+      # Optionally specify for broker nodes
+      # imagePullSecrets:
+      # - name: tutu
       druid.port: 8088
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
       replicas: 1

--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -55,6 +55,9 @@ type DruidClusterSpec struct {
 	// Required: Druid Docker Image
 	Image string `json:"image"`
 
+	// Optional: imagePullSecrets for private registries
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
 	// Optional: environment variables for druid containers
 	Env []v1.EnvVar `json:"env,omitempty"`
 
@@ -162,6 +165,9 @@ type DruidNodeSpec struct {
 
 	// Optional: Overrides image from top level
 	Image string `json:"image,omitempty"`
+
+	// Optional: Overrides imagePullSecrets from top level
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Optional: Extra environment variables
 	Env []v1.EnvVar `json:"env,omitempty"`

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -642,9 +642,9 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 					Annotations: firstNonNilValue(nodeSpec.PodAnnotations, m.Spec.PodAnnotations).(map[string]string),
 				},
 				Spec: v1.PodSpec{
-					NodeSelector: m.Spec.NodeSelector,
-					Tolerations:  tolerations,
-					Affinity:     affinity,
+					NodeSelector:     m.Spec.NodeSelector,
+					Tolerations:      tolerations,
+					Affinity:         affinity,
 					ImagePullSecrets: firstNonNilValue(nodeSpec.ImagePullSecrets, m.Spec.ImagePullSecrets).([]v1.LocalObjectReference),
 					Containers: []v1.Container{
 						{

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -645,6 +645,7 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 					NodeSelector: m.Spec.NodeSelector,
 					Tolerations:  tolerations,
 					Affinity:     affinity,
+					ImagePullSecrets: firstNonNilValue(nodeSpec.ImagePullSecrets, m.Spec.ImagePullSecrets).([]v1.LocalObjectReference),
 					Containers: []v1.Container{
 						{
 							Image:          firstNonEmptyStr(nodeSpec.Image, m.Spec.Image),


### PR DESCRIPTION
Fixes #24 (imagePullSecrets part)

### Description

Currently operator cannot pull custom built images private registeries which require authentication, add support for ImagePullSecrets option in StatefulSet.

You globally specify an imagePullSecrets
```
apiVersion: "druid.apache.org/v1alpha1"
kind: "Druid"
metadata:
  name: tiny-cluster
spec:
  image: apache/incubator-druid:0.16.0-incubating
  # Optionally specify image for all nodes. Can be specify on nodes also
  # imagePullSecrets:
  # - name: tutu
  startScript: /druid.sh
```
and/or be more specific juste for a node type 
```
nodes:
    brokers:
      nodeType: "broker"
      # Optionally specify for broker nodes
      # imagePullSecrets:
      # - name: tutu
      druid.port: 8088
      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
      replicas: 1
```

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [X] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [X] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * handler.go
 * druid_types.go
 * examples/tiny-cluster.yaml
