### PR TITLE
Update tiny-cluster.yaml

### DIFF
--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -177,3 +177,25 @@ spec:
           memory: "2G"
           cpu: "2"
           
+    routers:
+      nodeType: "router"
+      druid.port: 8888
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/router"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/router
+        druid.plaintextPort=8888
+
+        # HTTP proxy
+        druid.router.http.numConnections=50
+        druid.router.http.readTimeout=PT5M
+        druid.router.http.numMaxThreads=100
+        druid.server.http.numThreads=100
+
+        # Service discovery
+        druid.router.defaultBrokerServiceName=druid/broker
+        druid.router.coordinatorServiceName=druid/coordinator
+
+        # Management proxy to coordinator / overlord: required for unified web console.
+        druid.router.managementProxy.enabled=true       
+          


### PR DESCRIPTION
# Description
Router Node type generally is handy as otherwise web console is unavailable (?)

<hr>

This PR has:
- [y] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [n] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [y] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [n] added documentation for new or modified features or behaviors.

