### PR TITLE
PVC For deployments

### DIFF
--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -229,6 +229,11 @@ type DruidNodeSpec struct {
 	// Optional: Ingress Spec
 	Ingress *extensions.IngressSpec `json:"ingress,omitempty"`
 
+	// Optional: Persitance Volume Spec for Deployments
+	PersistentVolumeClaim *v1.PersistentVolumeClaimSpec `json:"persistentVolumeClaim,omitempty"`
+
+	// Optional: MounthPath to mount volume
+	PersistentVolumeClaimMounthPath string `json:"persistentVolumeClaimMountPath,omitempty"`
 	// Optional
 	Lifecycle *v1.Lifecycle `json:"lifecycle,omitempty"`
 
@@ -256,14 +261,15 @@ type DeepStorageSpec struct {
 }
 
 type DruidClusterStatus struct {
-	StatefulSets         []string `json:"statefulSets,omitempty"`
-	Deployments          []string `json:"deployments,omitempty"`
-	Services             []string `json:"services,omitempty"`
-	ConfigMaps           []string `json:"configMaps,omitempty"`
-	PodDisruptionBudgets []string `json:"podDisruptionBudgets,omitempty"`
-	Ingress              []string `json:"ingress,omitempty"`
-	HPAutoScalers        []string `json:"hpAutoscalers,omitempty"`
-	Pods                 []string `json:"pods,omitempty"`
+	StatefulSets          []string `json:"statefulSets,omitempty"`
+	Deployments           []string `json:"deployments,omitempty"`
+	Services              []string `json:"services,omitempty"`
+	ConfigMaps            []string `json:"configMaps,omitempty"`
+	PodDisruptionBudgets  []string `json:"podDisruptionBudgets,omitempty"`
+	Ingress               []string `json:"ingress,omitempty"`
+	PersistentVolumeClaim []string `json:"persistentVolumeClaim,omitempty"`
+	HPAutoScalers         []string `json:"hpAutoscalers,omitempty"`
+	Pods                  []string `json:"pods,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -233,6 +233,11 @@ func (in *DruidClusterStatus) DeepCopyInto(out *DruidClusterStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PersistentVolumeClaim != nil {
+		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.HPAutoScalers != nil {
 		in, out := &in.HPAutoScalers, &out.HPAutoScalers
 		*out = make([]string, len(*in))
@@ -260,7 +265,7 @@ func (in *DruidClusterStatus) DeepCopy() *DruidClusterStatus {
 func (in *DruidList) DeepCopyInto(out *DruidList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]Druid, len(*in))
@@ -398,6 +403,11 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 	if in.Ingress != nil {
 		in, out := &in.Ingress, &out.Ingress
 		*out = new(extensionsv1beta1.IngressSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PersistentVolumeClaim != nil {
+		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Lifecycle != nil {


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
- PersistentVolumeClaims to be deployed by operator and mounted to deployments nodes. 
- To support MM which can be run as deployments + use full for heap dumps after pod killed for troubleshooting.

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->
- PVC creation to take place before node deployed so that mount does not get stuck in.
- PVC name is kept to `nodeSpecUniqueStr` the operator manages volumeMounts and volumes. no need to manually add, just specify the MountPath during creation.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `types.go`
 * `handler.go`
