### PR TITLE
Fix: wrong file path on Druid CR Spec doc

### DIFF
--- a/docs/druid_cr.md
+++ b/docs/druid_cr.md
@@ -2,7 +2,7 @@
 
 - Druid CR has a ```clusterSpec``` which is common for all the druid nodes deployed and a ```nodeSpec``` which is specific to druid nodes.
 - Some key values are ```Required```, ie they must be present in the spec to get the cluster deployed. Other's are optional.
-- For full details on spec refer to ```pkg/api/druid/v1alpha1/druid_types.go```
+- For full details on spec refer to ```pkg/apis/druid/v1alpha1/druid_types.go```
 - The operator supports both deployments and statefulsets for druid Nodes. ```kind``` can be specified in the druid NodeSpec's to ```Deployment``` / ```StatefulSet```.
 - ```NOTE: The default behavior shall provision all the nodes as statefulsets.```
 


### PR DESCRIPTION
### Description

Fix wrong `druid_types.go` file path in Druid CR Spec doc.

##### Key changed/added files in this PR

 * `docs/druid_cr.md`
