### PR TITLE
Fix #88: DenyList for operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          # Following namespaces will not be reconciled by operator, regardless of scope        
+          #  - name: DENY_LIST
+          #    value: kube-system, default
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,6 +30,11 @@ druid-operator$ kubectl describe deployment druid-operator
 ```
 - Use ```ClusterRole``` and ```CluterRoleBinding``` instead of ```role```and ```roleBinding```.
 
+
+## Deny List in Operator
+- There may be use cases where we want the operator to watch all namespaces but restrict few namespaces, due to security, testing flexibility etc reasons.
+- The druid operator supports such cases. In ```deploy/operator.yaml```, user can enable ```DENY_LIST``` env and pass the namespaces to be excluded. Each namespace to be seperated using a comma.
+
 ## Deploy a sample Druid cluster
 
 - An example spec to deploy a tiny druid cluster is included. For full details on spec please see `pkg/api/druid/v1alpha1/druid_types.go`

--- a/pkg/controller/druid/druid_controller.go
+++ b/pkg/controller/druid/druid_controller.go
@@ -2,6 +2,8 @@ package druid
 
 import (
 	"context"
+	"time"
+
 	druidv1alpha1 "github.com/druid-io/druid-operator/pkg/apis/druid/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 var log = logf.Log.WithName("controller_druid")
@@ -42,7 +43,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource Druid
-	err = c.Watch(&source.Kind{Type: &druidv1alpha1.Druid{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &druidv1alpha1.Druid{}}, &handler.EnqueueRequestForObject{}, ignoreNamespacePredicate())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/druid/predicates.go
+++ b/pkg/controller/druid/predicates.go
@@ -1,0 +1,35 @@
+package druid
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ignoreNamespacePredicate(), called before re-concilation loop in watcher
+func ignoreNamespacePredicate() predicate.Predicate {
+	namespaces := getEnvAsSlice("DENY_LIST", nil, ",")
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			for _, namespace := range namespaces {
+				if e.Meta.GetNamespace() == namespace {
+					msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.Meta.GetNamespace())
+					log.Info(msg)
+					return false
+				}
+			}
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			for _, namespace := range namespaces {
+				if e.MetaNew.GetNamespace() == namespace {
+					msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.MetaNew.GetNamespace())
+					log.Info(msg)
+					return false
+				}
+			}
+			return true
+		},
+	}
+}

--- a/pkg/controller/druid/util.go
+++ b/pkg/controller/druid/util.go
@@ -1,7 +1,9 @@
 package druid
 
 import (
+	"os"
 	"reflect"
+	"strings"
 )
 
 func firstNonEmptyStr(s1 string, s2 string) string {
@@ -19,4 +21,23 @@ func firstNonNilValue(v1, v2 interface{}) interface{} {
 	} else {
 		return v2
 	}
+}
+
+// lookup DENY_LIST, default is nil
+func getDenyListEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
+}
+
+// pass slice of strings for namespaces
+func getEnvAsSlice(name string, defaultVal []string, sep string) []string {
+	valStr := getDenyListEnv(name, "")
+	if valStr == "" {
+		return defaultVal
+	}
+	// split on ","
+	val := strings.Split(valStr, sep)
+	return val
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #88 ( fixes denylist issue, operator can also support list of namespace to watch )

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
- As discussed in the issue above #88 , this PR shall enable a denyList which can ignoring/excluding namespace from re-conciliation regardless of operator scope

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->
- Added predicates.go , predicates will filter namespaces from API events, and will not send those to reconcile loop.
- Few util function to grab DENY_LIST as an env, and split out the namespaces string on ```,```.
- Added docs and comments where needed.
- pkg introduced : https://godoc.org/sigs.k8s.io/controller-runtime/pkg/predicate

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>
@himanshug @nishantmonu51 

##### Key changed/added files in this PR
 * `predicates.go`
 * `druid_controller.go`
 * `utils.go`
![image](https://user-images.githubusercontent.com/34169002/98594897-484be080-22fb-11eb-9492-bb9e7ae880b0.png)
