### PR TITLE
add support for ImagePullPolicy

### DIFF
--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -68,6 +68,9 @@ type DruidClusterSpec struct {
 	// Optional: imagePullSecrets for private registries
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
+	// Optional:
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// Optional: environment variables for druid containers
 	Env []v1.EnvVar `json:"env,omitempty"`
 
@@ -203,6 +206,9 @@ type DruidNodeSpec struct {
 
 	// Optional: Overrides imagePullSecrets from top level
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
+	// Optional: Overrides imagePullPolicy from top level
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Optional: Extra environment variables
 	Env []v1.EnvVar `json:"env,omitempty"`

--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -913,6 +913,7 @@ func makePodSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUn
 				Image:           firstNonEmptyStr(nodeSpec.Image, m.Spec.Image),
 				Name:            fmt.Sprintf("%s", nodeSpecUniqueStr),
 				Command:         []string{firstNonEmptyStr(m.Spec.StartScript, "bin/run-druid.sh"), nodeSpec.NodeType},
+				ImagePullPolicy: v1.PullPolicy(firstNonEmptyStr(string(nodeSpec.ImagePullPolicy), string(m.Spec.ImagePullPolicy))),
 				Ports:           nodeSpec.Ports,
 				Resources:       nodeSpec.Resources,
 				Env:             getEnv(nodeSpec, m, configMapSHA),


### PR DESCRIPTION


### Description

Adds support for customizing the ImagePullPolicy to a non-default value, both at cluster and nodeSpec leve.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`

