### PR TITLE
Fixes #98: Log when validation fails

### DIFF
--- a/pkg/controller/druid/handler.go
+++ b/pkg/controller/druid/handler.go
@@ -51,6 +51,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 	if err := verifyDruidSpec(m); err != nil {
 		e := fmt.Errorf("invalid DruidSpec[%s:%s] due to [%s]", m.Kind, m.Name, err.Error())
 		sendEvent(sdk, m, v1.EventTypeWarning, "SPEC_INVALID", e.Error())
+		logger.Error(e, e.Error(), "name", m.Name, "namespace", m.Namespace)
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #98

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
