### PR TITLE
Fix: pvc provisioned by operator

### DIFF
--- a/pkg/apis/druid/v1alpha1/druid_types.go
+++ b/pkg/apis/druid/v1alpha1/druid_types.go
@@ -249,6 +249,9 @@ type DruidNodeSpec struct {
 	// Optional
 	Lifecycle *v1.Lifecycle `json:"lifecycle,omitempty"`
 
+	// Optional: Persitance Volume Spec
+	PersistentVolumeClaim *v1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec,omitempty"`
+
 	// Optional
 	HPAutoScaler *autoscalev2beta1.HorizontalPodAutoscalerSpec `json:"hpAutoscaler,omitempty"`
 
@@ -273,14 +276,15 @@ type DeepStorageSpec struct {
 }
 
 type DruidClusterStatus struct {
-	StatefulSets         []string `json:"statefulSets,omitempty"`
-	Deployments          []string `json:"deployments,omitempty"`
-	Services             []string `json:"services,omitempty"`
-	ConfigMaps           []string `json:"configMaps,omitempty"`
-	PodDisruptionBudgets []string `json:"podDisruptionBudgets,omitempty"`
-	Ingress              []string `json:"ingress,omitempty"`
-	HPAutoScalers        []string `json:"hpAutoscalers,omitempty"`
-	Pods                 []string `json:"pods,omitempty"`
+	StatefulSets          []string `json:"statefulSets,omitempty"`
+	Deployments           []string `json:"deployments,omitempty"`
+	Services              []string `json:"services,omitempty"`
+	ConfigMaps            []string `json:"configMaps,omitempty"`
+	PodDisruptionBudgets  []string `json:"podDisruptionBudgets,omitempty"`
+	Ingress               []string `json:"ingress,omitempty"`
+	PersistentVolumeClaim []string `json:"persistentVolumeClaim,omitempty"`
+	HPAutoScalers         []string `json:"hpAutoscalers,omitempty"`
+	Pods                  []string `json:"pods,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -238,6 +238,11 @@ func (in *DruidClusterStatus) DeepCopyInto(out *DruidClusterStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PersistentVolumeClaim != nil {
+		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.HPAutoScalers != nil {
 		in, out := &in.HPAutoScalers, &out.HPAutoScalers
 		*out = make([]string, len(*in))
@@ -413,6 +418,11 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 	if in.Lifecycle != nil {
 		in, out := &in.Lifecycle, &out.Lifecycle
 		*out = new(v1.Lifecycle)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PersistentVolumeClaim != nil {
+		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.HPAutoScaler != nil {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

https://github.com/druid-io/druid-operator/pull/70
As discussed in the above PR, operator provisions pvcs, user can specify using volume mounts

once approved/discussed will add documentation

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `types.go`
* `handler.go`
