### PR TITLE
add a smoke test that deploy operator, a cr and validates reconciliation using controller-runtime envtest package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,22 @@
 FROM golang:1.13 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
 
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
+# Install Kubebuilder
+ARG OS_ARCH=amd64
+ARG KUBEBUILDER_VERSION=2.3.1
+RUN curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz"
+RUN tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz
+RUN mv kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH} kubebuilder && mv kubebuilder /usr/local/
+RUN export PATH=$PATH:/usr/local/kubebuilder/bin
+
+COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go fmt ./...
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go vet ./...
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test ./...
+RUN go mod download
+RUN go fmt ./...
+RUN go vet ./...
+RUN go test ./...
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/controllers/druid/handler_test.go
+++ b/controllers/druid/handler_test.go
@@ -117,7 +117,11 @@ func TestMakeBrokerConfigMap(t *testing.T) {
 }
 
 func readSampleDruidClusterSpec(t *testing.T) *v1alpha1.Druid {
-	bytes, err := ioutil.ReadFile("testdata/druid-test-cr.yaml")
+	return readDruidClusterSpecFromFile(t, "testdata/druid-test-cr.yaml")
+}
+
+func readDruidClusterSpecFromFile(t *testing.T, filePath string) *v1alpha1.Druid {
+	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		t.Errorf("Failed to read druid cluster spec")
 	}

--- a/controllers/druid/testdata/druid-smoke-test-cluster.yaml
+++ b/controllers/druid/testdata/druid-smoke-test-cluster.yaml
@@ -1,0 +1,208 @@
+apiVersion: "druid.apache.org/v1alpha1"
+kind: "Druid"
+metadata:
+  name: smoke-test
+  namespace: default
+spec:
+  image: druidio/druid:test
+  # Optionally specify image for all nodes. Can be specify on nodes also
+  # imagePullSecrets:
+  # - name: tutu
+  startScript: /druid.sh
+  podLabels:
+    environment: stage
+    release: alpha
+  podAnnotations:
+    dummykey: dummyval
+  readinessProbe:
+    httpGet:
+      path: /status
+      port: 8088
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+    runAsGroup: 1000
+  services:
+    - spec:
+        type: ClusterIP
+        clusterIP: None
+  commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
+  jvm.options: |-
+    -server
+    -XX:MaxDirectMemorySize=10240g
+    -Duser.timezone=UTC
+    -Dfile.encoding=UTF-8
+    -Dlog4j.debug
+    -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+    -Djava.io.tmpdir=/druid/data/tmp
+  log4j.config: |-
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <Configuration status="WARN">
+        <Appenders>
+            <Console name="Console" target="SYSTEM_OUT">
+                <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+            </Console>
+        </Appenders>
+        <Loggers>
+            <Root level="info">
+                <AppenderRef ref="Console"/>
+            </Root>
+        </Loggers>
+    </Configuration>
+  common.runtime.properties: |
+
+    # Zookeeper
+
+    # Metadata Store
+    druid.metadata.storage.type=derby
+    druid.metadata.storage.type=derby
+    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
+    druid.metadata.storage.connector.host=localhost
+    druid.metadata.storage.connector.port=1527
+    druid.metadata.storage.connector.createTables=true
+
+    # Deep Storage
+    druid.storage.type=local
+    druid.storage.storageDirectory=/druid/deepstorage
+
+    #
+    # Extensions
+    #
+    druid.extensions.loadList=[""]
+
+    #
+    # Service discovery
+    #
+    druid.selectors.indexing.serviceName=druid/overlord
+    druid.selectors.coordinator.serviceName=druid/coordinator
+
+    druid.serverview.type=http
+    druid.coordinator.loadqueuepeon.type=http
+    druid.indexer.runner.type=httpRemote
+    druid.indexer.logs.type=file
+    druid.indexer.logs.directory=/druid/data/indexing-logs
+    druid.lookup.enableLookupSyncOnStartup=false
+  volumeMounts:
+    - mountPath: /druid/data
+      name: data-volume
+    - mountPath: /druid/deepstorage
+      name: deepstorage-volume
+  volumes:
+    - name: data-volume
+      emptyDir: {}
+    - name: deepstorage-volume
+      hostPath:
+        path: /tmp/druid/deepstorage
+        type: DirectoryOrCreate
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+  nodes:
+    brokers:
+      # Optionally specify for running broker as Deployment
+      # kind: Deployment
+      nodeType: "broker"
+      kind: "Deployment"
+      # Optionally specify for broker nodes
+      # imagePullSecrets:
+      # - name: tutu
+      druid.port: 8088
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
+      replicas: 1
+      podDisruptionBudgetSpec:
+        minAvailable: 1
+      hpAutoscaler:
+        maxReplicas: 3
+        minReplicas: 1
+        scaleTargetRef:
+          apiVersion: apps/v1
+          kind: Deployment
+          name: druid-smoke-test-brokers
+      runtime.properties: |
+        druid.service=druid/broker
+
+        # HTTP server threads
+        druid.broker.http.numConnections=5
+        druid.server.http.numThreads=10
+
+        # Processing threads and buffers
+        druid.processing.buffer.sizeBytes=1
+        druid.processing.numMergeBuffers=1
+        druid.processing.numThreads=1
+        druid.sql.enable=true
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
+
+    coordinators:
+      # Optionally specify for running coordinator as Deployment
+      # kind: Deployment
+      nodeType: "coordinator"
+      druid.port: 8088
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/master/coordinator-overlord"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/coordinator
+
+        # HTTP server threads
+        druid.coordinator.startDelay=PT30S
+        druid.coordinator.period=PT30S
+
+        # Configure this coordinator to also run as Overlord
+        druid.coordinator.asOverlord.enabled=true
+        druid.coordinator.asOverlord.overlordService=druid/overlord
+        druid.indexer.queue.startDelay=PT30S
+        druid.indexer.runner.type=local
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
+
+    historicals:
+      nodeType: "historical"
+      druid.port: 8088
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/data/historical"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/historical
+        druid.server.http.numThreads=5
+        druid.processing.buffer.sizeBytes=1
+        druid.processing.numMergeBuffers=1
+        druid.processing.numThreads=1
+        # Segment storage
+        druid.segmentCache.locations=[{\"path\":\"/druid/data/segments\",\"maxSize\":10737418240}]
+        druid.server.maxSize=10737418240
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
+          
+    routers:
+      nodeType: "router"
+      druid.port: 8088
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/router"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/router
+
+        # HTTP proxy
+        druid.router.http.numConnections=10
+        druid.router.http.readTimeout=PT5M
+        druid.router.http.numMaxThreads=10
+        druid.server.http.numThreads=10
+
+        # Service discovery
+        druid.router.defaultBrokerServiceName=druid/broker
+        druid.router.coordinatorServiceName=druid/coordinator
+
+        # Management proxy to coordinator / overlord: required for unified web console.
+        druid.router.managementProxy.enabled=true       
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
+          

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
+	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2


### PR DESCRIPTION

note that envtest ( https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest ) brings up only the k8s API Server and not all the usual controllers but still good enough to test that operator was able to create necessary resources it was supposed to and submitted them to API server.