### PR TITLE
reconcile sts/deploy if replica count changed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.13
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
-	github.com/onsi/ginkgo v1.11.0
-	github.com/onsi/gomega v1.8.1
 	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2


### PR DESCRIPTION
Fixes #108


### Description

This PR introduces the mechanism to do comparison of resources generated by druid-operator so as to reconcile them if they were changed directly. currently it only does so for the Deployment/StatefulSet replica counts but could be extended further as needed.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [] added documentation for new or modified features or behaviors.

<hr>

