### PR TITLE
add ingress resource test suite

### DIFF
--- a/controllers/druid/suite_test.go
+++ b/controllers/druid/suite_test.go
@@ -8,12 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/types"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -150,6 +151,13 @@ func testDruidOperator(t *testing.T, testK8sCtx *TestK8sEnvCtx) {
 		}
 		if !areStringArraysEqual(druid.Status.HPAutoScalers, expectedHPAs) {
 			return errors.New(fmt.Sprintf("Failed to get expected HPAs, got [%v]", druid.Status.HPAutoScalers))
+		}
+
+		expectedIngress := []string{
+			fmt.Sprintf("druid-%s-routers", druidCR.Name),
+		}
+		if !areStringArraysEqual(druid.Status.Ingress, expectedIngress) {
+			return errors.New(fmt.Sprintf("Failed to get expected Ingress, got [%v]", druid.Status.Ingress))
 		}
 
 		return nil

--- a/controllers/druid/testdata/druid-smoke-test-cluster.yaml
+++ b/controllers/druid/testdata/druid-smoke-test-cluster.yaml
@@ -187,6 +187,19 @@ spec:
       druid.port: 8088
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/router"
       replicas: 1
+      ingress:
+        tls:
+         - hosts:
+            - sslexample.foo.com
+           secretName: testsecret-tls
+        rules:
+         - host: sslexample.foo.com
+           http:
+             paths:
+             - path: /
+               backend:
+                 serviceName: service1
+                 servicePort: 80
       runtime.properties: |
         druid.service=druid/router
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

- Add ingress resource in test suite

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `suite_test.go`