### PR TITLE
make tiny-clyster.yaml a working example

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,6 +51,8 @@ druid-operator$ kubectl apply -f examples/tiny-cluster-zk.yaml
 druid-operator$ kubectl apply -f examples/tiny-cluster.yaml
 ```
 
+Note that above tiny-cluster only works on a single node kubernetes cluster(e.g. typical k8s cluster setup for dev using kind or minikube) as it uses local disk as "deep storage".
+
 ## Debugging Problems
 
  - For kubernetes version 1.11 make sure to disable ```type: object``` in the CRD root spec. 

--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -3,7 +3,7 @@ kind: "Druid"
 metadata:
   name: tiny-cluster
 spec:
-  image: apache/druid:0.19.0
+  image: apache/druid:0.20.0
   # Optionally specify image for all nodes. Can be specify on nodes also
   # imagePullSecrets:
   # - name: tutu
@@ -11,6 +11,12 @@ spec:
   podLabels:
     environment: stage
     release: alpha
+  podAnnotations:
+    dummykey: dummyval
+  readinessProbe:
+    httpGet:
+      path: /status/health
+      port: 8088
   securityContext:
     fsGroup: 1000
     runAsUser: 1000
@@ -27,6 +33,7 @@ spec:
     -Dfile.encoding=UTF-8
     -Dlog4j.debug
     -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+    -Djava.io.tmpdir=/druid/data
   log4j.config: |-
     <?xml version="1.0" encoding="UTF-8" ?>
     <Configuration status="WARN">
@@ -50,26 +57,51 @@ spec:
 
     # Metadata Store
     druid.metadata.storage.type=derby
-    druid.metadata.storage.type=derby
-    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/var/druid/metadata.db;create=true
+    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
     druid.metadata.storage.connector.host=localhost
     druid.metadata.storage.connector.port=1527
     druid.metadata.storage.connector.createTables=true
 
     # Deep Storage
     druid.storage.type=local
-    druid.storage.storageDirectory=/druid/data/deepstorage
+    druid.storage.storageDirectory=/druid/deepstorage
 
     #
     # Extensions
     #
-    druid.extensions.loadList=["druid-s3-extensions"]
+    druid.extensions.loadList=["druid-kafka-indexing-service"]
 
     #
     # Service discovery
     #
     druid.selectors.indexing.serviceName=druid/overlord
     druid.selectors.coordinator.serviceName=druid/coordinator
+
+    druid.indexer.logs.type=file
+    druid.indexer.logs.directory=/druid/data/indexing-logs
+    druid.lookup.enableLookupSyncOnStartup=false
+  volumeMounts:
+    - mountPath: /druid/data
+      name: data-volume
+    - mountPath: /druid/deepstorage
+      name: deepstorage-volume
+  volumes:
+    - name: data-volume
+      emptyDir: {}
+    - name: deepstorage-volume
+      hostPath:
+        path: /tmp/druid/deepstorage
+        type: DirectoryOrCreate
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
   nodes:
     brokers:
       # Optionally specify for running broker as Deployment
@@ -92,23 +124,10 @@ spec:
         druid.processing.buffer.sizeBytes=1
         druid.processing.numMergeBuffers=1
         druid.processing.numThreads=1
-        druid.sql.enable=false
+        druid.sql.enable=true
       extra.jvm.options: |-
-        -Xmx1G
-        -Xms1G
-      volumeMounts:
-        - mountPath: /druid/data
-          name: data-volume
-      volumes:
-        - name: data-volume
-          emptyDir: {}
-      resources:
-        requests:
-          memory: "2G"
-          cpu: "2"
-        limits:
-          memory: "2G"
-          cpu: "2"
+        -Xmx512M
+        -Xms512M
 
     coordinators:
       # Optionally specify for running coordinator as Deployment
@@ -130,21 +149,8 @@ spec:
         druid.indexer.queue.startDelay=PT30S
         druid.indexer.runner.type=local
       extra.jvm.options: |-
-        -Xmx1G
-        -Xms1G
-      volumeMounts:
-        - mountPath: /druid/data
-          name: data-volume
-      volumes:
-        - name: data-volume
-          emptyDir: {}
-      resources:
-        requests:
-          memory: "2G"
-          cpu: "2"
-        limits:
-          memory: "2G"
-          cpu: "2"
+        -Xmx512M
+        -Xms512M
 
     historicals:
       nodeType: "historical"
@@ -154,43 +160,29 @@ spec:
       runtime.properties: |
         druid.service=druid/historical
         druid.server.http.numThreads=5
-        druid.processing.buffer.sizeBytes=1
+        druid.processing.buffer.sizeBytes=536870912
         druid.processing.numMergeBuffers=1
         druid.processing.numThreads=1
         # Segment storage
         druid.segmentCache.locations=[{\"path\":\"/druid/data/segments\",\"maxSize\":10737418240}]
         druid.server.maxSize=10737418240
       extra.jvm.options: |-
-        -Xmx1G
-        -Xms1G
-      volumeMounts:
-        - mountPath: /druid/data
-          name: data-volume
-      volumes:
-        - name: data-volume
-          emptyDir: {}
-      resources:
-        requests:
-          memory: "2G"
-          cpu: "2"
-        limits:
-          memory: "2G"
-          cpu: "2"
+        -Xmx512M
+        -Xms512M
           
     routers:
       nodeType: "router"
-      druid.port: 8888
+      druid.port: 8088
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/router"
       replicas: 1
       runtime.properties: |
         druid.service=druid/router
-        druid.plaintextPort=8888
 
         # HTTP proxy
-        druid.router.http.numConnections=50
+        druid.router.http.numConnections=10
         druid.router.http.readTimeout=PT5M
-        druid.router.http.numMaxThreads=100
-        druid.server.http.numThreads=100
+        druid.router.http.numMaxThreads=10
+        druid.server.http.numThreads=10
 
         # Service discovery
         druid.router.defaultBrokerServiceName=druid/broker
@@ -198,4 +190,7 @@ spec:
 
         # Management proxy to coordinator / overlord: required for unified web console.
         druid.router.managementProxy.enabled=true       
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
           


### PR DESCRIPTION
Linked #107

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

examples/tiny-cluster.yaml is a working example now, when running on a single node k8s cluster as it uses local disk as "deep storage",  that deploys a small Druid cluster. I followed the "Example Data" flow on router web console to load the example data and queried from sql editor in same after indexing task was successful.

How to visit router web console:
After cluster is deployed successfully, setup port forwarding to router using
```
kubectl port-forward druid-tiny-cluster-routers-0 8088
```
then visit `http://localhost:8088/`

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

