### PR TITLE
add envFrom in podSpec

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -6,6 +6,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
@@ -63,6 +64,9 @@ type DruidSpec struct {
 
 	// Optional: environment variables for druid containers
 	Env []v1.EnvVar `json:"env,omitempty"`
+
+	// Optional: Extra environment variables
+	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Optional: jvm options for druid jvm processes
 	JvmOptions string `json:"jvm.options,omitempty"`
@@ -197,6 +201,9 @@ type DruidNodeSpec struct {
 
 	// Optional: Extra environment variables
 	Env []v1.EnvVar `json:"env,omitempty"`
+
+	// Optional: Extra environment variables
+	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Optional: CPU/Memory Resources
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -804,6 +804,11 @@ func getStartUpProbe(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) *v1.Pr
 	return startUpProbe
 }
 
+func getEnvFrom(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []v1.EnvFromSource {
+	envFromHolder := firstNonNilValue(nodeSpec.EnvFrom, m.Spec.EnvFrom).([]v1.EnvFromSource)
+	return envFromHolder
+}
+
 func getRollingUpdateStrategy(nodeSpec *v1alpha1.DruidNodeSpec) *appsv1.RollingUpdateDeployment {
 	var nil *int32 = nil
 	if nodeSpec.MaxSurge != nil || nodeSpec.MaxUnavailable != nil {
@@ -940,6 +945,7 @@ func makePodSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, nodeSpecUn
 				Ports:           nodeSpec.Ports,
 				Resources:       nodeSpec.Resources,
 				Env:             getEnv(nodeSpec, m, configMapSHA),
+				EnvFrom:         getEnvFrom(nodeSpec, m),
 				VolumeMounts:    getVolumeMounts(nodeSpec, m),
 				LivenessProbe:   getLivenessProbe(nodeSpec, m),
 				ReadinessProbe:  getReadinessProbe(nodeSpec, m),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #131 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
 * `druid_types.go`