### PR TITLE
update ingress to use networkingv1beta1 api

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -6,7 +6,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -241,7 +241,7 @@ type DruidNodeSpec struct {
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 
 	// Optional: Ingress Spec
-	Ingress *extensions.IngressSpec `json:"ingress,omitempty"`
+	Ingress *networkingv1beta1.IngressSpec `json:"ingress,omitempty"`
 
 	// Optional
 	Lifecycle *v1.Lifecycle `json:"lifecycle,omitempty"`

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -13,7 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/api/policy/v1beta1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -153,6 +153,13 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
@@ -210,7 +217,7 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 	}
 	if in.Ingress != nil {
 		in, out := &in.Ingress, &out.Ingress
-		*out = new(extensionsv1beta1.IngressSpec)
+		*out = new(networkingv1beta1.IngressSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Lifecycle != nil {
@@ -267,6 +274,13 @@ func (in *DruidSpec) DeepCopyInto(out *DruidSpec) {
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/druid-io/druid-operator/apis/druid/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -295,7 +295,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 	updatedStatus.Ingress = deleteUnusedResources(sdk, m, ingressNames, ls,
 		func() runtime.Object { return makeIngressListEmptyObj() },
 		func(listObj runtime.Object) []object {
-			items := listObj.(*extensions.IngressList).Items
+			items := listObj.(*networkingv1beta1.IngressList).Items
 			result := make([]object, len(items))
 			for i := 0; i < len(items); i++ {
 				result[i] = &items[i]
@@ -1166,10 +1166,10 @@ func makeHorizontalPodAutoscaler(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.D
 	return hpa, nil
 }
 
-func makeIngress(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[string]string, nodeSpecUniqueStr string) (*extensions.Ingress, error) {
+func makeIngress(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[string]string, nodeSpecUniqueStr string) (*networkingv1beta1.Ingress, error) {
 	nodeIngressSpec := *nodeSpec.Ingress
 
-	ingress := &extensions.Ingress{
+	ingress := &networkingv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "networking.k8s.io/v1beta1",
 			Kind:       "Ingress",
@@ -1268,8 +1268,8 @@ func makeHorizontalPodAutoscalerListEmptyObj() *autoscalev2beta1.HorizontalPodAu
 	}
 }
 
-func makeIngressListEmptyObj() *extensions.IngressList {
-	return &extensions.IngressList{
+func makeIngressListEmptyObj() *networkingv1beta1.IngressList {
+	return &networkingv1beta1.IngressList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "networking.k8s.io/v1beta1",
 			Kind:       "Ingress",
@@ -1340,8 +1340,8 @@ func makePersistentVolumeClaimListEmptyObj() *v1.PersistentVolumeClaimList {
 	}
 }
 
-func makeIngressEmptyObj() *extensions.Ingress {
-	return &extensions.Ingress{
+func makeIngressEmptyObj() *networkingv1beta1.Ingress {
+	return &networkingv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "networking.k8s.io/v1beta1",
 			Kind:       "Ingress",

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -93,7 +93,7 @@ helm -n druid-operator uninstall cluster-druid-operator
 
 ## Deploy a sample Druid cluster
 
-- An example spec to deploy a tiny druid cluster is included. For full details on spec please see `pkg/api/druid/v1alpha1/druid_types.go`
+- An example spec to deploy a tiny druid cluster is included. For full details on spec please see `apis/druid/v1alpha1/druid_types.go`
 
 ```
 # deploy single node zookeeper


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->
- ingress to use networking v1beta1, this has been tested on 1.18 k8s. 
- 1.20 has stable ingress with networking/v1, but v1 is not available on 1.20 so kept ing to v1beta1.
- This introduces a ingressClass field , more described here https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
*  `druid_types.go`