### PR TITLE
Delete unmounted/orphaned pvc

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -46,6 +46,9 @@ type DruidSpec struct {
 	// Optional: Default is set to false, pvc shall be deleted on deletion of CR
 	DisablePVCDeletionFinalizer bool `json:"disablePVCDeletionFinalizer"`
 
+	// Optional: Default is set to true, orphaned ( unmounted pvc's ) shall be cleaned up by the operator.
+	DeleteOrphanPvc bool `json:"deleteOrphanPvc"`
+
 	// Required: path to druid start script to be run on container start
 	StartScript string `json:"startScript"`
 

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -153,6 +153,13 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
@@ -267,6 +274,13 @@ func (in *DruidSpec) DeepCopyInto(out *DruidSpec) {
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -253,10 +253,12 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 		}
 	}
 
-	if err := deleteOrphanPVC(sdk, m); err != nil {
-		e := fmt.Errorf("Error in deleteOrphanPVC [%s]", err.Error())
-		sendEvent(sdk, m, v1.EventTypeWarning, "LIST_FAIL", e.Error())
-		logger.Error(e, e.Error(), "name", m.Name, "namespace", m.Namespace)
+	if m.Spec.DeleteOrphanPvc {
+		if err := deleteOrphanPVC(sdk, m); err != nil {
+			e := fmt.Errorf("Error in deleteOrphanPVC [%s]", err.Error())
+			sendEvent(sdk, m, v1.EventTypeWarning, "LIST_FAIL", e.Error())
+			logger.Error(e, e.Error(), "name", m.Name, "namespace", m.Namespace)
+		}
 	}
 
 	//update status and delete unwanted resources

--- a/deploy/crds/druid.apache.org_druids.yaml
+++ b/deploy/crds/druid.apache.org_druids.yaml
@@ -764,6 +764,10 @@ spec:
                 - spec
                 - type
                 type: object
+              deleteOrphanPvc:
+                description: 'Optional: Default is set to true, orphaned ( unmounted
+                  pvc''s ) shall be cleaned up by the operator.'
+                type: boolean
               disablePVCDeletionFinalizer:
                 description: 'Optional: Default is set to false, pvc shall be deleted
                   on deletion of CR'
@@ -7575,6 +7579,7 @@ spec:
             required:
             - common.runtime.properties
             - commonConfigMountPath
+            - deleteOrphanPvc
             - disablePVCDeletionFinalizer
             - nodes
             - startScript

--- a/deploy/crds/druid.apache.org_druids.yaml
+++ b/deploy/crds/druid.apache.org_druids.yaml
@@ -764,6 +764,10 @@ spec:
                 - spec
                 - type
                 type: object
+              disablePVCDeletionFinalizer:
+                description: 'Optional: Default is set to false, pvc shall be deleted
+                  on deletion of CR'
+                type: boolean
               env:
                 description: 'Optional: environment variables for druid containers'
                 items:
@@ -865,6 +869,39 @@ spec:
                       type: object
                   required:
                   - name
+                  type: object
+                type: array
+              envFrom:
+                description: 'Optional: Extra environment variables'
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
                   type: object
                 type: array
               forceDeleteStsPodOnError:
@@ -1897,6 +1934,43 @@ spec:
                             type: object
                         required:
                         - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: 'Optional: Extra environment variables'
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
                         type: object
                       type: array
                     extra.jvm.options:
@@ -7501,6 +7575,7 @@ spec:
             required:
             - common.runtime.properties
             - commonConfigMountPath
+            - disablePVCDeletionFinalizer
             - nodes
             - startScript
             type: object

--- a/deploy/crds/druid.apache.org_druids.yaml
+++ b/deploy/crds/druid.apache.org_druids.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -764,10 +763,6 @@ spec:
                 - spec
                 - type
                 type: object
-              deleteOrphanPvc:
-                description: 'Optional: Default is set to true, orphaned ( unmounted
-                  pvc''s ) shall be cleaned up by the operator.'
-                type: boolean
               disablePVCDeletionFinalizer:
                 description: 'Optional: Default is set to false, pvc shall be deleted
                   on deletion of CR'
@@ -7579,8 +7574,6 @@ spec:
             required:
             - common.runtime.properties
             - commonConfigMountPath
-            - deleteOrphanPvc
-            - disablePVCDeletionFinalizer
             - nodes
             - startScript
             type: object


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #136

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->
- As discussed in the issue, this PR will make sure unmounted PVC's are deleted on each reconcile. 
<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go` 
 
 @himanshug 