### PR TITLE
fix delete pvc race condition

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -507,6 +507,18 @@ func deleteOrphanPVC(sdk client.Client, drd *v1alpha1.Druid) error {
 		return err
 	}
 
+	// Fix: https://github.com/druid-io/druid-operator/issues/149
+	for _, pod := range podList {
+		if pod.Status.Phase != v1.PodRunning {
+			return nil
+		}
+		for _, status := range pod.Status.Conditions {
+			if status.Status != v1.ConditionTrue {
+				return nil
+			}
+		}
+	}
+
 	mountedPVC := make([]string, len(podList))
 	for _, pod := range podList {
 		if pod.Spec.Volumes != nil {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #149 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
