### PR TITLE
Fix CRD to support PVC name and labels. Also adding annotations to services.

### DIFF
--- a/deploy/crds/druid.apache.org_druids.yaml
+++ b/deploy/crds/druid.apache.org_druids.yaml
@@ -3363,6 +3363,20 @@ spec:
                           metadata:
                             description: 'Standard object''s metadata. More info:
                               https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                descriptions: 'Optional: Service annotations.'
+                                type: object
+                              name:
+                                description: 'Name of service.'
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                descriptions: 'Optional: Service labels.'
+                                type: object
                             type: object
                           spec:
                             description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -3846,6 +3860,15 @@ spec:
                           metadata:
                             description: 'Standard object''s metadata. More info:
                               https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              name:
+                                description: 'Name of volume.'
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                descriptions: 'Volume labels.'
+                                type: object
                             type: object
                           spec:
                             description: 'Spec defines the desired characteristics


### PR DESCRIPTION
Fixes #135 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

This PR should resolve the issue mentioned in #135. The PVC name will get prepended to the naming scheme, so that we don't end up with PVC names like "-druid-druid-historicals-0", which are invalid.

This PR also adds the ability to add annotations to services. My main rationale for this was to allow for the creation of internal AWS ELBs with annotations such as:

```
    service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "5"

    service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "3"

    service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "2"

    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
```

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `druid.apache.org_druids.yaml` 
