### PR TITLE
nil for emptyslice

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -938,7 +938,7 @@ func getServiceName(nameTemplate, nodeSpecUniqueStr string) string {
 }
 
 func getPersistentVolumeClaim(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []v1.PersistentVolumeClaim {
-	var pvc []v1.PersistentVolumeClaim
+	var pvc = []v1.PersistentVolumeClaim{}
 
 	for _, val := range m.Spec.VolumeClaimTemplates {
 		pvc = append(pvc, val)
@@ -978,7 +978,7 @@ func getNodeConfigMountPath(nodeSpec *v1alpha1.DruidNodeSpec) string {
 
 func getTolerations(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []v1.Toleration {
 
-	var tolerations []v1.Toleration
+	var tolerations = []v1.Toleration{}
 
 	for _, val := range m.Spec.Tolerations {
 		tolerations = append(tolerations, val)

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -938,7 +938,7 @@ func getServiceName(nameTemplate, nodeSpecUniqueStr string) string {
 }
 
 func getPersistentVolumeClaim(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []v1.PersistentVolumeClaim {
-	pvc := []v1.PersistentVolumeClaim{}
+	var pvc []v1.PersistentVolumeClaim
 
 	for _, val := range m.Spec.VolumeClaimTemplates {
 		pvc = append(pvc, val)
@@ -953,6 +953,7 @@ func getPersistentVolumeClaim(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Drui
 }
 
 func getVolumeMounts(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []v1.VolumeMount {
+
 	volumeMount := []v1.VolumeMount{
 		{
 			MountPath: firstNonEmptyStr(m.Spec.CommonConfigMountPath, defaultCommonConfigMountPath),
@@ -976,7 +977,8 @@ func getNodeConfigMountPath(nodeSpec *v1alpha1.DruidNodeSpec) string {
 }
 
 func getTolerations(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) []v1.Toleration {
-	tolerations := []v1.Toleration{}
+
+	var tolerations []v1.Toleration
 
 	for _, val := range m.Spec.Tolerations {
 		tolerations = append(tolerations, val)


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
