### PR TITLE
Support PVC Creation For Deployments

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -246,6 +246,9 @@ type DruidNodeSpec struct {
 	// Optional: Ingress Spec
 	Ingress *networkingv1beta1.IngressSpec `json:"ingress,omitempty"`
 
+	// Optional: Persistant volume claim
+	PersistentVolumeClaim []v1.PersistentVolumeClaim `json:"persistentVolumeClaim,omitempty"`
+
 	// Optional
 	Lifecycle *v1.Lifecycle `json:"lifecycle,omitempty"`
 
@@ -277,14 +280,15 @@ type DruidStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	StatefulSets         []string `json:"statefulSets,omitempty"`
-	Deployments          []string `json:"deployments,omitempty"`
-	Services             []string `json:"services,omitempty"`
-	ConfigMaps           []string `json:"configMaps,omitempty"`
-	PodDisruptionBudgets []string `json:"podDisruptionBudgets,omitempty"`
-	Ingress              []string `json:"ingress,omitempty"`
-	HPAutoScalers        []string `json:"hpAutoscalers,omitempty"`
-	Pods                 []string `json:"pods,omitempty"`
+	StatefulSets           []string `json:"statefulSets,omitempty"`
+	Deployments            []string `json:"deployments,omitempty"`
+	Services               []string `json:"services,omitempty"`
+	ConfigMaps             []string `json:"configMaps,omitempty"`
+	PodDisruptionBudgets   []string `json:"podDisruptionBudgets,omitempty"`
+	Ingress                []string `json:"ingress,omitempty"`
+	HPAutoScalers          []string `json:"hpAutoscalers,omitempty"`
+	Pods                   []string `json:"pods,omitempty"`
+	PersistentVolumeClaims []string `json:"persistentVolumeClaims,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -220,6 +220,13 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 		*out = new(networkingv1beta1.IngressSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PersistentVolumeClaim != nil {
+		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
+		*out = make([]v1.PersistentVolumeClaim, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Lifecycle != nil {
 		in, out := &in.Lifecycle, &out.Lifecycle
 		*out = new(v1.Lifecycle)
@@ -450,6 +457,11 @@ func (in *DruidStatus) DeepCopyInto(out *DruidStatus) {
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.PersistentVolumeClaims != nil {
+		in, out := &in.PersistentVolumeClaims, &out.PersistentVolumeClaims
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -921,7 +921,7 @@ func makeService(svc *v1.Service, nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.
 		Kind:       "Service",
 	}
 
-	svc.ObjectMeta.Name = getSvcName(svc.ObjectMeta.Name, nodeSpecUniqueStr)
+	svc.ObjectMeta.Name = getServiceName(svc.ObjectMeta.Name, nodeSpecUniqueStr)
 
 	svc.ObjectMeta.Namespace = m.Namespace
 
@@ -954,7 +954,7 @@ func makeService(svc *v1.Service, nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.
 	return svc, nil
 }
 
-func getSvcName(nameTemplate, nodeSpecUniqueStr string) string {
+func getServiceName(nameTemplate, nodeSpecUniqueStr string) string {
 	if nameTemplate == "" {
 		return nodeSpecUniqueStr
 	} else {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

- PVC's can be created for deployments too.
- Use case such as capturing heapdumps in pvc post pod deletion/restart.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
 * `types.go`
