### PR TITLE
revert reconciliation on direct statefulset/deployment replica count change made by HPA or anything else

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1120,11 +1120,12 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 	}, nil
 }
 
-// currently only checks for replica count mismatch, can be extended further
 func statefulSetIsEquals(obj1, obj2 object) bool {
-	o1 := obj1.(*appsv1.StatefulSet)
-	o2 := obj2.(*appsv1.StatefulSet)
-	return *o1.Spec.Replicas == *o2.Spec.Replicas
+
+	// This used to match replica counts, but was reverted to fix https://github.com/druid-io/druid-operator/issues/160
+	// because it is legitimate for HPA to change replica counts and operator shouldn't reset those.
+
+	return true;
 }
 
 // makeDeployment shall create deployment object.
@@ -1143,11 +1144,12 @@ func makeDeployment(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[
 	}, nil
 }
 
-// currently only checks for replica count mismatch, can be extended further
 func deploymentIsEquals(obj1, obj2 object) bool {
-	o1 := obj1.(*appsv1.Deployment)
-	o2 := obj2.(*appsv1.Deployment)
-	return *o1.Spec.Replicas == *o2.Spec.Replicas
+
+	// This used to match replica counts, but was reverted to fix https://github.com/druid-io/druid-operator/issues/160
+	// because it is legitimate for HPA to change replica counts and operator shouldn't reset those.
+
+	return true;
 }
 
 // makeStatefulSetSpec shall create statefulset spec for statefulsets.


### PR DESCRIPTION
Fixes #160


### Description

Do not reconcile statefulset/deployment when replica count is updated by something outside of operator e.g. HPA.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
