### PR TITLE
Force cluster creation parallel, rolling deploy sequential

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -179,7 +179,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 				}
 
 				// Ignore isObjFullyDeployed() for the first iteration ie cluster creation
-				// will force cluster cretion in parallel, post first iternation rolling updates
+				// will force cluster creation in parallel, post first iteration rolling updates
 				// will be sequential.
 				if m.Generation > 1 {
 					// Check Deployment rolling update status, if in-progress then stop here
@@ -209,7 +209,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 				execCheckCrashStatus(sdk, &nodeSpec, m)
 
 				// Ignore isObjFullyDeployed() for the first iteration ie cluster creation
-				// will force cluster cretion in parallel, post first iternation rolling updates
+				// will force cluster creation in parallel, post first iteration rolling updates
 				// will be sequential.
 				if m.Generation > 1 {
 					//Check StatefulSet rolling update status, if in-progress then stop here

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -178,10 +178,15 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 					return nil
 				}
 
-				// Check Deployment rolling update status, if in-progress then stop here
-				done, err := isObjFullyDeployed(sdk, nodeSpecUniqueStr, m, func() object { return makeDeploymentEmptyObj() })
-				if !done {
-					return err
+				// Ignore isObjFullyDeployed() for the first iteration ie cluster creation
+				// will force cluster cretion in parallel, post first iternation rolling updates
+				// will be sequential.
+				if m.Generation > 1 {
+					// Check Deployment rolling update status, if in-progress then stop here
+					done, err := isObjFullyDeployed(sdk, nodeSpecUniqueStr, m, func() object { return makeDeploymentEmptyObj() })
+					if !done {
+						return err
+					}
 				}
 			}
 		} else {
@@ -203,10 +208,15 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid) error {
 				// Default is set to true
 				execCheckCrashStatus(sdk, &nodeSpec, m)
 
-				//Check StatefulSet rolling update status, if in-progress then stop here
-				done, err := isObjFullyDeployed(sdk, nodeSpecUniqueStr, m, func() object { return makeStatefulSetEmptyObj() })
-				if !done {
-					return err
+				// Ignore isObjFullyDeployed() for the first iteration ie cluster creation
+				// will force cluster cretion in parallel, post first iternation rolling updates
+				// will be sequential.
+				if m.Generation > 1 {
+					//Check StatefulSet rolling update status, if in-progress then stop here
+					done, err := isObjFullyDeployed(sdk, nodeSpecUniqueStr, m, func() object { return makeStatefulSetEmptyObj() })
+					if !done {
+						return err
+					}
 				}
 			}
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #177.

- regardless of roling deploy set to true/false, cluster creation should be parallel.
- call objectFullyDeployed only when generation tag is > 1.
- generation tag increments on each apply/edit to the CR.
- During the first iteration generation tag is 1. 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
