### PR TITLE
Make predicates extensible

### DIFF
--- a/controllers/druid/druid_controller.go
+++ b/controllers/druid/druid_controller.go
@@ -58,7 +58,7 @@ func (r *DruidReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 func (r *DruidReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&druidv1alpha1.Druid{}).
-		WithEventFilter(ignoreNamespacePredicate()).
+		WithEventFilter(GenericPredicates{}).
 		Complete(r)
 }
 

--- a/controllers/druid/predicates.go
+++ b/controllers/druid/predicates.go
@@ -15,40 +15,24 @@ type GenericPredicates struct {
 
 // create() to filter create events
 func (GenericPredicates) Create(e event.CreateEvent) bool {
-	namespaces := getEnvAsSlice("DENY_LIST", nil, ",")
-
-	for _, namespace := range namespaces {
-		if e.Object.GetNamespace() == namespace {
-			msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.Object.GetNamespace())
-			logger.Info(msg)
-			return false
-		}
-	}
-	return true
-
+	return IgnoreNamespacePredicate(e.Object)
 }
 
 // update() to filter update events
 func (GenericPredicates) Update(e event.UpdateEvent) bool {
+	return IgnoreNamespacePredicate(e.ObjectNew)
+
+}
+
+func IgnoreNamespacePredicate(obj object) bool {
 	namespaces := getEnvAsSlice("DENY_LIST", nil, ",")
 
 	for _, namespace := range namespaces {
-		if e.ObjectNew.GetNamespace() == namespace {
-			msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.ObjectNew.GetNamespace())
+		if obj.GetNamespace() == namespace {
+			msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", obj.GetNamespace())
 			logger.Info(msg)
 			return false
 		}
 	}
 	return true
-
 }
-
-// Delete() to filter delete events
-//func (GenericPredicates) Delete(e event.DeleteEvent) bool {
-//	return true
-//}
-
-// Genreric() to filter generic events
-//func (GenericPredicates)  Genreric(e event.GenericEvent) bool {
-//	return true
-//}

--- a/controllers/druid/predicates.go
+++ b/controllers/druid/predicates.go
@@ -7,29 +7,48 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// ignoreNamespacePredicate(), called before re-concilation loop in watcher
-func ignoreNamespacePredicate() predicate.Predicate {
-	namespaces := getEnvAsSlice("DENY_LIST", nil, ",")
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			for _, namespace := range namespaces {
-				if e.Object.GetNamespace() == namespace {
-					msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.Object.GetNamespace())
-					logger.Info(msg)
-					return false
-				}
-			}
-			return true
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			for _, namespace := range namespaces {
-				if e.ObjectNew.GetNamespace() == namespace {
-					msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.ObjectNew.GetNamespace())
-					logger.Info(msg)
-					return false
-				}
-			}
-			return true
-		},
-	}
+// All methods to implement GenericPredicates type
+// GenericPredicates to be passed to manager
+type GenericPredicates struct {
+	predicate.Funcs
 }
+
+// create() to filter create events
+func (GenericPredicates) Create(e event.CreateEvent) bool {
+	namespaces := getEnvAsSlice("DENY_LIST", nil, ",")
+
+	for _, namespace := range namespaces {
+		if e.Object.GetNamespace() == namespace {
+			msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.Object.GetNamespace())
+			logger.Info(msg)
+			return false
+		}
+	}
+	return true
+
+}
+
+// update() to filter update events
+func (GenericPredicates) Update(e event.UpdateEvent) bool {
+	namespaces := getEnvAsSlice("DENY_LIST", nil, ",")
+
+	for _, namespace := range namespaces {
+		if e.ObjectNew.GetNamespace() == namespace {
+			msg := fmt.Sprintf("druid operator will not re-concile namespace [%s], alter DENY_LIST to re-concile", e.ObjectNew.GetNamespace())
+			logger.Info(msg)
+			return false
+		}
+	}
+	return true
+
+}
+
+// Delete() to filter delete events
+//func (GenericPredicates) Delete(e event.DeleteEvent) bool {
+//	return true
+//}
+
+// Genreric() to filter generic events
+//func (GenericPredicates)  Genreric(e event.GenericEvent) bool {
+//	return true
+//}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #194

- The manager just accepts a single predicate, current implementation did not allow to add more funcs.
- So i have added a GenericPredicate type which all methods shall implement.
- We can just pass the type to manager event filters.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `predicates.go`
 * `druid_controller.go`
