### PR TITLE
refactor objfullydeployed()

### DIFF
--- a/controllers/druid/interface.go
+++ b/controllers/druid/interface.go
@@ -20,20 +20,21 @@ const (
 )
 
 const (
-	DruidNodeUpdateFail            string = "UPDATE_FAIL"
-	DruidNodeUpdateSuccess         string = "UPDATE_SUCCESS"
-	DruidNodeRollingDeploymentWait string = "ROLLING_DEPLOYMENT_WAIT"
-	DruidNodeDeleteFail            string = "DELETE_FAIL"
-	DruidNodeDeleteSuccess         string = "DELETE_SUCCESS"
-	DruidNodeCreateSuccess         string = "CREATE_SUCCESS"
-	DruidNodeCreateFail            string = "CREATE_FAIL"
-	DruidNodePatchFail             string = "PATCH_FAIL"
-	DruidSpecInvalid               string = "SPEC_INVALID"
-	DruidNodeRunning               string = "RUNNING"
-	DruidObjectListFail            string = "LIST_FAIL"
-	DruidOjectGetFail              string = "GET_FAIL"
-	DruidFinalizerSuccess          string = "TRIGGER_FINALIZER_SUCCESS"
-	DruidFinalizer                 string = "TRIGGER_FINALIZER"
+	DruidNodeUpdateFail        string = "UPDATE_FAIL"
+	DruidNodeUpdateSuccess     string = "UPDATE_SUCCESS"
+	DruidNodeRollingDeployWait string = "ROLLING_DEPLOY_WAIT"
+	DruidNodeRollingDeployFail string = "ROLLING_DEPLOY_FAIL"
+	DruidNodeDeleteFail        string = "DELETE_FAIL"
+	DruidNodeDeleteSuccess     string = "DELETE_SUCCESS"
+	DruidNodeCreateSuccess     string = "CREATE_SUCCESS"
+	DruidNodeCreateFail        string = "CREATE_FAIL"
+	DruidNodePatchFail         string = "PATCH_FAIL"
+	DruidSpecInvalid           string = "SPEC_INVALID"
+	DruidNodeRunning           string = "RUNNING"
+	DruidObjectListFail        string = "LIST_FAIL"
+	DruidOjectGetFail          string = "GET_FAIL"
+	DruidFinalizerSuccess      string = "TRIGGER_FINALIZER_SUCCESS"
+	DruidFinalizer             string = "TRIGGER_FINALIZER"
 )
 
 // Reader Interface


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #196

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
- main goal was to detect failures during rolling deploy.
- Deployment has conditions to detect so have added those.
- Statefulsets does not have status conditions its TODO in upstream https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/apps/types.go#L217

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
