### PR TITLE
Cloud examples using druid-k8s-extension

### DIFF
--- a/examples/cloud/do-druid.yaml
+++ b/examples/cloud/do-druid.yaml
@@ -49,19 +49,30 @@ spec:
       emptyDir: {}
   common.runtime.properties: |
 
+    # metadata storage
     druid.metadata.storage.type=derby
     druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
     druid.metadata.storage.connector.host=localhost
     druid.metadata.storage.connector.port=1527
     druid.metadata.storage.connector.createTables=true
 
+    # deep storage
     druid.storage.type=s3
-    druid.storage.bucket=bucket_name
+    druid.storage.bucket=bucketname
     druid.storage.baseKey=druid/segments
-    druid.s3.endpoint.url=nyc.digitaloceanspaces.com:443
-    druid.s3.endpoint.signingRegion=nyc
-    druid.s3.accessKey=EXAMPLEACCESSKEY
-    druid.s3.secretKey=EXAMPLESECRETACCESSKEY
+    druid.s3.endpoint.url=fra1.digitaloceanspaces.com:443
+    druid.s3.endpoint.signingRegion=fra1
+    druid.s3.accessKey=VBACCESSKEYPJ
+    druid.s3.secretKey=mSeCrEtKeyyY
+
+    # druid-k8s-extension-configuration
+    druid.zk.service.enabled=false
+    druid.serverview.type=http
+    druid.coordinator.loadqueuepeon.type=http
+    druid.indexer.runner.type=httpRemote
+    druid.discovery.type=k8s
+    druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+
     #
     # Extensions
     #
@@ -90,7 +101,6 @@ spec:
       replicas: 1
       runtime.properties: |
         druid.service=druid/broker
-        
         # HTTP server threads
         druid.broker.http.numConnections=1
         druid.server.http.numThreads=1
@@ -99,14 +109,6 @@ spec:
         druid.processing.numMergeBuffers=1
         druid.processing.numThreads=1
         druid.sql.enable=true
-
-        # druid-k8s-extension-configuration
-        druid.zk.service.enabled=false
-        druid.serverview.type=http
-        druid.coordinator.loadqueuepeon.type=http
-        druid.indexer.runner.type=httpRemote
-        druid.discovery.type=k8s
-        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
 
     coordinators:
       kind: Deployment
@@ -120,19 +122,10 @@ spec:
         druid.coordinator.startDelay=PT30S
         druid.coordinator.period=PT30S
 
-        # druid-k8s-extension-configuration
-        druid.zk.service.enabled=false
-        druid.serverview.type=http
-        druid.coordinator.loadqueuepeon.type=http
-        druid.indexer.runner.type=httpRemote
-        druid.discovery.type=k8s
-        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
-
         # Configure this coordinator to also run as Overlord
         druid.coordinator.asOverlord.enabled=true
         druid.coordinator.asOverlord.overlordService=druid/overlord
         druid.indexer.queue.startDelay=PT30S
-        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
@@ -165,17 +158,8 @@ spec:
         druid.processing.numMergeBuffers=1
         druid.processing.numThreads=1
 
-        # druid-k8s-extension-configuration
-        druid.zk.service.enabled=false
-        druid.serverview.type=http
-        druid.coordinator.loadqueuepeon.type=http
-        druid.indexer.runner.type=httpRemote
-        druid.discovery.type=k8s
-        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
-
         druid.segmentCache.locations=[{"path":"var/druid/segment-cache","maxSize":40000000}]
         druid.server.maxSize=40000000000
-    
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
@@ -200,14 +184,6 @@ spec:
           druid.indexer.fork.property.druid.processing.numMergeBuffers=2
           druid.indexer.fork.property.druid.processing.buffer.sizeBytes=100MiB
           druid.indexer.fork.property.druid.processing.numThreads=1
-          
-          # druid-k8s-extension-configuration
-          druid.zk.service.enabled=false
-          druid.serverview.type=http
-          druid.coordinator.loadqueuepeon.type=http
-          druid.indexer.runner.type=httpRemote
-          druid.discovery.type=k8s
-          druid.discovery.k8s.clusterIdentifier=us-west-do-druid
       volumeClaimTemplates:
         -
           metadata:
@@ -237,14 +213,6 @@ spec:
         druid.router.http.readTimeout=PT5M
         druid.router.http.numMaxThreads=10
         druid.server.http.numThreads=10
-
-        # druid-k8s-extension-configuration
-        druid.zk.service.enabled=false
-        druid.serverview.type=http
-        druid.coordinator.loadqueuepeon.type=http
-        druid.indexer.runner.type=httpRemote
-        druid.discovery.type=k8s
-        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
 
         # Service discovery
         druid.router.defaultBrokerServiceName=druid/broker

--- a/examples/cloud/do-druid.yaml
+++ b/examples/cloud/do-druid.yaml
@@ -1,0 +1,256 @@
+apiVersion: "druid.apache.org/v1alpha1"
+kind: "Druid"
+metadata:
+  name: do-cluster
+spec:
+  image: apache/druid:0.21.1
+  startScript: /druid.sh
+  podLabels:
+    environment: do
+    release: alpha
+  podAnnotations:
+    cloud: do
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+    runAsGroup: 1000
+  services:
+    - spec:
+        type: ClusterIP
+        clusterIP: None
+  commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
+  jvm.options: |-
+    -server
+    -XX:MaxDirectMemorySize=10240g
+    -Duser.timezone=UTC
+    -Dfile.encoding=UTF-8
+    -Dlog4j.debug
+    -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+    -Djava.io.tmpdir=/druid/data
+  log4j.config: |-
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <Configuration status="WARN">
+        <Appenders>
+            <Console name="Console" target="SYSTEM_OUT">
+                <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+            </Console>
+        </Appenders>
+        <Loggers>
+            <Root level="info">
+                <AppenderRef ref="Console"/>
+            </Root>
+        </Loggers>
+    </Configuration>
+  volumeMounts:
+    - mountPath: /druid/data
+      name: data-volume
+  volumes:
+    - name: data-volume
+      emptyDir: {}
+  common.runtime.properties: |
+
+    druid.metadata.storage.type=derby
+    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
+    druid.metadata.storage.connector.host=localhost
+    druid.metadata.storage.connector.port=1527
+    druid.metadata.storage.connector.createTables=true
+
+    druid.storage.type=s3
+    druid.storage.bucket=bucket_name
+    druid.storage.baseKey=druid/segments
+    druid.s3.endpoint.url=nyc.digitaloceanspaces.com:443
+    druid.s3.endpoint.signingRegion=nyc
+    druid.s3.accessKey=EXAMPLEACCESSKEY
+    druid.s3.secretKey=EXAMPLESECRETACCESSKEY
+    #
+    # Extensions
+    #
+    druid.extensions.loadList=["druid-kafka-indexing-service","druid-s3-extensions","druid-kubernetes-extensions"]
+    #
+    # Service discovery
+    #
+    druid.selectors.indexing.serviceName=druid/overlord
+    druid.selectors.coordinator.serviceName=druid/coordinator
+    druid.lookup.enableLookupSyncOnStartup=false
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+  nodes:
+    brokers:
+      kind: Deployment
+      nodeType: "broker"
+      druid.port: 8080
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/broker
+        
+        # HTTP server threads
+        druid.broker.http.numConnections=1
+        druid.server.http.numThreads=1
+        # Processing threads and buffers
+        druid.processing.buffer.sizeBytes=1
+        druid.processing.numMergeBuffers=1
+        druid.processing.numThreads=1
+        druid.sql.enable=true
+
+        # druid-k8s-extension-configuration
+        druid.zk.service.enabled=false
+        druid.serverview.type=http
+        druid.coordinator.loadqueuepeon.type=http
+        druid.indexer.runner.type=httpRemote
+        druid.discovery.type=k8s
+        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+
+    coordinators:
+      kind: Deployment
+      nodeType: "coordinator"
+      druid.port: 8080
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/master/coordinator-overlord"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/coordinator
+        # HTTP server threads
+        druid.coordinator.startDelay=PT30S
+        druid.coordinator.period=PT30S
+
+        # druid-k8s-extension-configuration
+        druid.zk.service.enabled=false
+        druid.serverview.type=http
+        druid.coordinator.loadqueuepeon.type=http
+        druid.indexer.runner.type=httpRemote
+        druid.discovery.type=k8s
+        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+
+        # Configure this coordinator to also run as Overlord
+        druid.coordinator.asOverlord.enabled=true
+        druid.coordinator.asOverlord.overlordService=druid/overlord
+        druid.indexer.queue.startDelay=PT30S
+        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
+
+    historicals:
+      nodeType: "historical"
+      druid.port: 8080
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/data/historical"
+      replicas: 1
+      volumeClaimTemplates:
+        -
+          metadata:
+            name: historical-volume
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+            storageClassName: do-block-storage
+      volumeMounts:
+        -
+          mountPath: var/druid
+          name: historical-volume
+      runtime.properties: |
+        druid.service=druid/historical
+        druid.server.http.numThreads=1
+        druid.processing.buffer.sizeBytes=400000
+        druid.processing.tmpDir=var/druid/processing
+        druid.processing.numMergeBuffers=1
+        druid.processing.numThreads=1
+
+        # druid-k8s-extension-configuration
+        druid.zk.service.enabled=false
+        druid.serverview.type=http
+        druid.coordinator.loadqueuepeon.type=http
+        druid.indexer.runner.type=httpRemote
+        druid.discovery.type=k8s
+        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+
+        druid.segmentCache.locations=[{"path":"var/druid/segment-cache","maxSize":40000000}]
+        druid.server.maxSize=40000000000
+    
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M
+
+    middlemanagers:
+      druid.port: 8080
+      kind: StatefulSet
+      nodeType: middleManager
+      nodeConfigMountPath: /opt/druid/conf/druid/cluster/data/middleManager
+      podDisruptionBudgetSpec:
+        maxUnavailable: 1
+      replicas: 1
+      runtime.properties: |
+          druid.service=druid/middleManager
+          druid.worker.capacity=4
+          druid.indexer.runner.javaOpts=-server -Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+          druid.indexer.task.baseTaskDir=var/druid/task
+
+          # HTTP server threads    
+          druid.server.http.numThreads=60
+          # Processing threads and buffers on Peons
+          druid.indexer.fork.property.druid.processing.numMergeBuffers=2
+          druid.indexer.fork.property.druid.processing.buffer.sizeBytes=100MiB
+          druid.indexer.fork.property.druid.processing.numThreads=1
+          
+          # druid-k8s-extension-configuration
+          druid.zk.service.enabled=false
+          druid.serverview.type=http
+          druid.coordinator.loadqueuepeon.type=http
+          druid.indexer.runner.type=httpRemote
+          druid.discovery.type=k8s
+          druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+      volumeClaimTemplates:
+        -
+          metadata:
+            name: data-volume
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 15Gi
+            storageClassName: do-block-storage
+      volumeMounts:
+        -
+          mountPath: var/druid
+          name: data-volume
+
+    routers:
+      nodeType: "router"
+      kind: Deployment
+      druid.port: 8888
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/router"
+      replicas: 1
+      runtime.properties: |
+        druid.service=druid/router
+        # HTTP proxy
+        druid.router.http.numConnections=10
+        druid.router.http.readTimeout=PT5M
+        druid.router.http.numMaxThreads=10
+        druid.server.http.numThreads=10
+
+        # druid-k8s-extension-configuration
+        druid.zk.service.enabled=false
+        druid.serverview.type=http
+        druid.coordinator.loadqueuepeon.type=http
+        druid.indexer.runner.type=httpRemote
+        druid.discovery.type=k8s
+        druid.discovery.k8s.clusterIdentifier=us-west-do-druid
+
+        # Service discovery
+        druid.router.defaultBrokerServiceName=druid/broker
+        druid.router.coordinatorServiceName=druid/coordinator
+        # Management proxy to coordinator / overlord: required for unified web console.
+        druid.router.managementProxy.enabled=true       
+      extra.jvm.options: |-
+        -Xmx512M
+        -Xms512M

--- a/examples/cloud/sa.yaml
+++ b/examples/cloud/sa.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: druid-cluster
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - '*'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: druid-cluster
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: druid-cluster
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

- cloud example for running druid with deepstorage using digital ocean spaces ( object store )
- using druid-k8s-extensions 

will add more cloud examples in this dir.

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `examples`


cc @himanshug @nishantmonu51 