### PR TITLE
Create watched_namespace.yaml

### DIFF
--- a/chart/templates/watched_namespace.yaml
+++ b/chart/templates/watched_namespace.yaml
@@ -1,0 +1,9 @@
+{{- $relname := (index .Values "druid-operator") -}}
+
+{{- if and ($relname.env.WATCH_NAMESPACE) (ne $relname.env.WATCH_NAMESPACE "default") }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $relname.env.WATCH_NAMESPACE }}
+{{- end }}

--- a/chart/templates/watched_namespace.yaml
+++ b/chart/templates/watched_namespace.yaml
@@ -1,5 +1,8 @@
+# Import the values when being called as dependency needs this line because of the dash '-'
 {{- $relname := (index .Values "druid-operator") -}}
 
+# Namespace set into WATCH_NAMESPACE environment var needs to exists to install this operator
+# When a namespace is declared and not the default, create that namespace
 {{- if and ($relname.env.WATCH_NAMESPACE) (ne $relname.env.WATCH_NAMESPACE "default") }}
 ---
 apiVersion: v1


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

I have a Druid cluster deployed with druid-operator Helm chart and deployment is being automated using FluxCD. When the operator is watching a defined namespace, this namespace needs to exists, in order not to fail.

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->
When Helm is in the template stage, under some conditions, declare that namespace too, as the watched_namespace.yaml manifest

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 *  ./druid-operator/chart/templates/watched_namespace.yaml 
