### PR TITLE
Fixing the image tag to be pulled for druid-operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: druid-operator
           # Replace this with the built image name
-          image: druid-operator:latest
+          image: druidio/druid-operator:latest
           command:
           - /manager
           imagePullPolicy: Always


### PR DESCRIPTION
 * the image tag fixed to druidio/druid-operator:latest

Fixes #258 

### Description

The druid-operator image was not getting pulled and led to ImagePullBackOff.
On `kubectl create -f deploy/operator.yaml`, we would land into ImagePullBackOff for druid-operator.

<hr>

This PR has:
- [ Y] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ N/A] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [N/A] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ N/A] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `deploy/operator.yaml`
