### PR TITLE
add support for druid 0.22.1 and zookeeper 3.7.0

### DIFF
--- a/examples/tiny-cluster-hpa.yaml
+++ b/examples/tiny-cluster-hpa.yaml
@@ -6,7 +6,7 @@ kind: "Druid"
 metadata:
   name: tiny-cluster
 spec:
-  image: apache/druid:0.20.0
+  image: apache/druid:0.22.1
   # Optionally specify image for all nodes. Can be specify on nodes also
   # imagePullSecrets:
   # - name: tutu

--- a/examples/tiny-cluster-zk.yaml
+++ b/examples/tiny-cluster-zk.yaml
@@ -35,13 +35,16 @@ spec:
       containers:
         - env:
             - name: ZOO_SERVERS
-              value: server.0=tiny-cluster-zk-0.tiny-cluster-zk:2888:3888
+              value: server.1=tiny-cluster-zk-0.tiny-cluster-zk:2888:3888;2181
             - name: SERVER_JVMFLAGS
               value: -Xms256m -Xmx256m
-          image: zookeeper:3.4.13
+          image: zookeeper:3.7
           name: tiny-cluster-zk
-          command: ["/bin/sh"]
-          args: ["-c", "ZOO_MY_ID=$(echo `hostname` | cut -d '-' -f2) /docker-entrypoint.sh zkServer.sh start-foreground"]
+          command:
+          - /bin/sh
+          args:
+          - -c
+          - ZOO_MY_ID=$(( $(echo `hostname -s` | sed 's/[^0-9]//g') + 1 )) /docker-entrypoint.sh zkServer.sh start-foreground
           ports:
             - containerPort: 2181
               name: zk-client-port

--- a/examples/tiny-cluster-zk.yaml
+++ b/examples/tiny-cluster-zk.yaml
@@ -38,7 +38,7 @@ spec:
               value: server.1=tiny-cluster-zk-0.tiny-cluster-zk:2888:3888;2181
             - name: SERVER_JVMFLAGS
               value: -Xms256m -Xmx256m
-          image: zookeeper:3.7
+          image: zookeeper:3.7.0
           name: tiny-cluster-zk
           command:
           - /bin/sh

--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -6,7 +6,7 @@ kind: "Druid"
 metadata:
   name: tiny-cluster
 spec:
-  image: apache/druid:0.20.0
+  image: apache/druid:0.22.1
   # Optionally specify image for all nodes. Can be specify on nodes also
   # imagePullSecrets:
   # - name: tutu


### PR DESCRIPTION
Fixes #256.

### Description

- Upgrade Apache Druid in example specs for deploying a tiny druid cluster to version 0.22.1, to solve the critical vulnerability CVE-2021-44228 in Apache Log4j.
- Upgrade ZooKeeper to 3.7.0, since starting with Apache Druid 0.22.0, support for ZooKeeper 3.4.x has been removed.
- Fix breaking changes in ZooKeeper configuration parameters: clientPort and clientPortAddress. Starting with 3.5.0, this information is part of the server keyword specification.

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `examples/tiny-cluster-hpa.yaml`
 * `examples/tiny-cluster-zk.yaml`
 * `examples/tiny-cluster.yaml`
