### PR TITLE
emit detect underlying object type on CRUD

### DIFF
--- a/controllers/druid/interface.go
+++ b/controllers/druid/interface.go
@@ -236,10 +236,10 @@ func (e EmitEventFuncs) EmitEventOnList(obj object, listObj objectList, err erro
 // EmitEventOnUpdate shall emit event on UPDATE operation
 func (e EmitEventFuncs) EmitEventOnUpdate(obj, updateObj object, err error) {
 	if err != nil {
-		errMsg := fmt.Errorf("Failed to update [%s:%s] due to [%s].", updateObj.GetName(), updateObj.GetObjectKind().GroupVersionKind().Kind, err.Error())
+		errMsg := fmt.Errorf("Failed to update [%s:%s] due to [%s].", updateObj.GetName(), detectType(updateObj), err.Error())
 		e.Event(obj, v1.EventTypeWarning, string(druidNodeUpdateFail), errMsg.Error())
 	} else {
-		msg := fmt.Sprintf("Updated [%s:%s].", updateObj.GetName(), updateObj.GetObjectKind().GroupVersionKind().Kind)
+		msg := fmt.Sprintf("Updated [%s:%s].", updateObj.GetName(), detectType(updateObj))
 		e.Event(obj, v1.EventTypeNormal, string(druidNodeUpdateSuccess), msg)
 	}
 }
@@ -247,10 +247,10 @@ func (e EmitEventFuncs) EmitEventOnUpdate(obj, updateObj object, err error) {
 // EmitEventOnDelete shall emit event on DELETE operation
 func (e EmitEventFuncs) EmitEventOnDelete(obj, deleteObj object, err error) {
 	if err != nil {
-		errMsg := fmt.Errorf("Error deleting object [%s:%s] in namespace [%s] due to [%s]", deleteObj.GetObjectKind().GroupVersionKind().Kind, deleteObj.GetName(), deleteObj.GetNamespace(), err.Error())
+		errMsg := fmt.Errorf("Error deleting object [%s:%s] in namespace [%s] due to [%s]", detectType(deleteObj), deleteObj.GetName(), deleteObj.GetNamespace(), err.Error())
 		e.Event(obj, v1.EventTypeWarning, string(druidNodeDeleteFail), errMsg.Error())
 	} else {
-		msg := fmt.Sprintf("Successfully deleted object [%s:%s] in namespace [%s]", deleteObj.GetName(), deleteObj.GetObjectKind().GroupVersionKind().Kind, deleteObj.GetNamespace())
+		msg := fmt.Sprintf("Successfully deleted object [%s:%s] in namespace [%s]", deleteObj.GetName(), detectType(deleteObj), deleteObj.GetNamespace())
 		e.Event(obj, v1.EventTypeNormal, string(druidNodeDeleteSuccess), msg)
 	}
 }
@@ -258,10 +258,10 @@ func (e EmitEventFuncs) EmitEventOnDelete(obj, deleteObj object, err error) {
 // EmitEventOnCreate shall emit event on CREATE operation
 func (e EmitEventFuncs) EmitEventOnCreate(obj, createObj object, err error) {
 	if err != nil {
-		errMsg := fmt.Errorf("Error creating object [%s] in namespace [%s:%s] due to [%s]", createObj.GetName(), createObj.GetObjectKind().GroupVersionKind().Kind, createObj.GetNamespace(), err.Error())
+		errMsg := fmt.Errorf("Error creating object [%s] in namespace [%s:%s] due to [%s]", createObj.GetName(), detectType(createObj), createObj.GetNamespace(), err.Error())
 		e.Event(obj, v1.EventTypeWarning, string(druidNodeCreateFail), errMsg.Error())
 	} else {
-		msg := fmt.Sprintf("Successfully created object [%s:%s] in namespace [%s]", createObj.GetName(), createObj.GetObjectKind().GroupVersionKind().Kind, createObj.GetNamespace())
+		msg := fmt.Sprintf("Successfully created object [%s:%s] in namespace [%s]", createObj.GetName(), detectType(createObj), createObj.GetNamespace())
 		e.Event(obj, v1.EventTypeNormal, string(druidNodeCreateSuccess), msg)
 	}
 }
@@ -269,10 +269,10 @@ func (e EmitEventFuncs) EmitEventOnCreate(obj, createObj object, err error) {
 // EmitEventOnPatch shall emit event on PATCH operation
 func (e EmitEventFuncs) EmitEventOnPatch(obj, patchObj object, err error) {
 	if err != nil {
-		errMsg := fmt.Errorf("Error patching object [%s:%s] in namespace [%s] due to [%s]", patchObj.GetName(), patchObj.GetObjectKind().GroupVersionKind().Kind, patchObj.GetNamespace(), err.Error())
+		errMsg := fmt.Errorf("Error patching object [%s:%s] in namespace [%s] due to [%s]", patchObj.GetName(), detectType(patchObj), patchObj.GetNamespace(), err.Error())
 		e.Event(obj, v1.EventTypeWarning, string(druidNodePatchFail), errMsg.Error())
 	} else {
-		msg := fmt.Sprintf("Successfully patched object [%s:%s] in namespace [%s]", patchObj.GetName(), patchObj.GetObjectKind().GroupVersionKind().Kind, patchObj.GetNamespace())
+		msg := fmt.Sprintf("Successfully patched object [%s:%s] in namespace [%s]", patchObj.GetName(), detectType(patchObj), patchObj.GetNamespace())
 		e.Event(obj, v1.EventTypeNormal, string(druidNodePatchSucess), msg)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #298 .

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
