### PR TITLE
make crd optional

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd.enabled }}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4832,3 +4833,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ env:
   RECONCILE_WAIT: "10s"            # Reconciliation delay
   WATCH_NAMESPACE: ""              # Namespace to watch or empty string to watch all namespaces, To watch multiple namespaces add , into string. Ex: WATCH_NAMESPACE: "ns1,ns2,ns3"
   #MAX_CONCURRENT_RECONCILES:: ""  # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
- 
+
 replicaCount: 1
 
 image:
@@ -76,3 +76,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+crd:
+  enabled: true


### PR DESCRIPTION
### Description

There is no way to disable crd deploy right now. It might be useful in case user does not have access to deploy crds which require cluster level permissions. 
This PR make crd optional but still enabled by default to keep backward compatibility.



##### Key changed/added files in this PR
 * `Chart.yaml` version bump
 * `druid.apache.org_druids.yaml`
 * `values.yaml`
