### PR TITLE
multiple watched namespaces

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -1,17 +1,17 @@
 {{- if .Values.rbac.create }}
+{{- $env := .Values.env }}
+{{- if and ($env.WATCH_NAMESPACE) (ne $env.WATCH_NAMESPACE "default") }}
+# Split WATCH_NAMESPACE by commas and loop on them
+{{- $watchedNamespaces := (split "," $env.WATCH_NAMESPACE) -}}
+{{- range $watchedNamespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.env.WATCH_NAMESPACE }}
 kind: Role
-{{- else }}
-kind: ClusterRole
-{{- end }}
 metadata:
-{{- if .Values.env.WATCH_NAMESPACE }}
-  namespace: {{ .Values.env.WATCH_NAMESPACE }}
-{{- end }}
-  name: {{ template "druid-operator.fullname" . }}
+  namespace: {{ . }}
+  name: {{ template "druid-operator.fullname" $ }}
   labels:
-    {{- include "druid-operator.labels" . | nindent 4 }}
+    {{- include "druid-operator.labels" $ | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -94,3 +94,111 @@ rules:
       - update
       - patch
 {{- end }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "druid-operator.fullname" $ }}
+  labels:
+    {{- include "druid-operator.labels" $ | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - services
+      - persistentvolumeclaims
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
+      - druid.apache.org
+    resources:
+      - druids
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - druid.apache.org
+    resources:
+      - druids/status
+    verbs:
+      - get
+      - update
+      - patch
+{{- end }}
+{{- end }}
+
+---
+# need clusterrole anyways
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "druid-operator.fullname" $ }}-sc
+  labels:
+    {{- include "druid-operator.labels" $ | nindent 4 }}
+rules:
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch

--- a/chart/templates/role_binding.yaml
+++ b/chart/templates/role_binding.yaml
@@ -1,23 +1,59 @@
 {{- if .Values.rbac.create }}
+{{- $env := .Values.env }}
+{{- $operatorName := (include "druid-operator.fullname" .) -}}
+{{- if and ($env.WATCH_NAMESPACE) (ne $env.WATCH_NAMESPACE "default") }}
+# Split WATCH_NAMESPACE by commas and loop on them
+{{- $watchedNamespaces := (split "," $env.WATCH_NAMESPACE) -}}
+{{- range $watchedNamespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.env.WATCH_NAMESPACE }}
 kind: RoleBinding
-{{- else }}
-kind: ClusterRoleBinding
-{{- end }}
 metadata:
-{{- if .Values.env.WATCH_NAMESPACE }}
-  namespace: {{ .Values.env.WATCH_NAMESPACE }}
-{{- end }}
-  name: {{ template "druid-operator.fullname" . }}
+  namespace: {{ . }}
+  name: {{ $operatorName }}
   labels:
-    {{- include "druid-operator.labels" . | nindent 4 }}
+    {{- include "druid-operator.labels" $ | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "druid-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "druid-operator.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
 roleRef:
-  kind: {{ if .Values.env.WATCH_NAMESPACE }} Role {{ else }} ClusterRole {{ end }}
-  name: {{ template "druid-operator.fullname" . }}
+  kind: Role
+  name: {{ $operatorName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "druid-operator.fullname" . -}}-sc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "druid-operator.labels" $ | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "druid-operator.serviceAccountName" $ }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "druid-operator.fullname" . }}-sc
+  apiGroup: rbac.authorization.k8s.io
+
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $operatorName }}
+  labels:
+    {{- include "druid-operator.labels" $ | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "druid-operator.serviceAccountName" $ }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $operatorName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}
+

--- a/chart/templates/watched_namespace.yaml
+++ b/chart/templates/watched_namespace.yaml
@@ -7,13 +7,12 @@
 {{- range $watchedNamespaces }}
 
 # Look for desired namespace to create when not existent
-{{- $relnamespace := (lookup "v1" "Namespace" "" .) -}}
-{{- if empty $relnamespace }}
+{{ if not ( lookup "v1" "Namespace" "" . ) }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "{{- . }}"
+  name:  {{ . }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #308 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
* Fixes problem when multiple namespaces are watched
* Fixes problem when `scaleStsPvc` is set to `true`\

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

When multiple namespaces are watched, configured by set `env.WATCH_NAMESPACE=ns1,ns2`, a role needs to be created in each of the namespaces.
Also, a clusterrole with list/get permission on `storage.k8s.io` api is needed in order for `scaleStsPvc` to work. All roles need to bind to the operator's service account.

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [X] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [X] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `chart/template/role.yaml`
 * `chart/templates/role_binding.yaml`
 * `chart/templates/watched_namespace.yaml`
