### PR TITLE
Fix-312-Run Test on CI, Controller Gen Version Update

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,10 +8,8 @@ on:
 
 jobs:
 
-  build:
-
+  tests:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Run Kubebuilder smoke and unit tests
@@ -20,5 +18,6 @@ jobs:
       run: make lint
     - name: Run helm template
       run: make template
+  build:
     - name: Build the Docker image
       run: docker build . -t druidio/druid-operator:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,5 @@ jobs:
       run: make lint
     - name: Run helm template
       run: make template
-  build:
     - name: Build the Docker image
       run: docker build . -t druidio/druid-operator:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . -t druidio/druid-operator:$(date +%s)
+      run: make test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,5 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Run Kubebuilder smoke and unit tests
+      run: make tests
+    - name: Run helm lint
+      run: make lint
+    - name: Run helm template
+      run: make template
     - name: Build the Docker image
-      run: make test
+      run: docker build . -t druidio/druid-operator:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run Kubebuilder smoke and unit tests
-      run: make tests
+      run: make test
     - name: Run helm lint
       run: make lint
     - name: Run helm template

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,37 +3,8 @@ FROM golang:1.19 as builder
 
 WORKDIR /workspace
 
-ARG K8S_VERSION=1.19.2
-ARG KUBEBUILDER_VERSION=2.3.1
-ARG HELM_VERSION=3.7.0
-
-# Install Kubebuilder
-ARG OS_ARCH=amd64
-RUN curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz"
-RUN tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH}.tar.gz
-RUN mv kubebuilder_${KUBEBUILDER_VERSION}_linux_${OS_ARCH} kubebuilder && mv kubebuilder /usr/local/
-RUN export PATH=$PATH:/usr/local/kubebuilder/bin
-
-# hack to update kubeapi-server to 1.19 version
-RUN curl -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${K8S_VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz"
-RUN tar -xzvf envtest-bins.tar.gz
-RUN rm -rf /usr/local/kubebuilder/bin/kube_apiserver
-RUN mv kubebuilder/bin/kube-apiserver /usr/local/kubebuilder/bin
-
-# Install helm
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-RUN chmod 700 get_helm.sh
-RUN ./get_helm.sh
-
-
 COPY . .
 
-# Build
-RUN make lint && make template
-RUN go mod download
-RUN go fmt ./...
-RUN go vet ./...
-RUN go test ./...
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=deploy/crds
+	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=chart/templates/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -1,11 +1,9 @@
-{{- if .Values.crd.enabled }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: druids.druid.apache.org
 spec:
@@ -20,114 +18,213 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Druid is the Schema for the druids API
         properties:
           apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
+            description: DruidSpec defines the desired state of Druid
             properties:
               additionalContainer:
+                description: Operator deploys the sidecar container based on these
+                  properties. Sidecar will be deployed for all the Druid pods.
                 items:
+                  description: AdditionalContainer defines the additional sidecar
+                    container
                   properties:
                     args:
+                      description: 'Optional: Argument to call the command'
                       items:
                         type: string
                       type: array
                     command:
+                      description: This is the command for the additional container
+                        to run. This is a required field
                       items:
                         type: string
                       type: array
                     containerName:
+                      description: This is the name of the additional container. This
+                        is a required field
                       type: string
                     env:
+                      description: 'Optional: environment variables for the Additional
+                        Container'
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
+                                x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                         required:
                         - name
                         type: object
                       type: array
                     envFrom:
+                      description: 'Optional: Extra environment variables'
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     image:
+                      description: This is the image for the additional container
+                        to run. This is a required field
                       type: string
                     imagePullPolicy:
+                      description: 'Optional: If not present, will be taken from top
+                        level spec'
                       type: string
                     resources:
+                      description: 'Optional: CPU/Memory Resources'
                       properties:
                         limits:
                           additionalProperties:
@@ -136,6 +233,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -144,83 +243,221 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     securityContext:
+                      description: 'Optional: ContainerSecurityContext. If not present,
+                        will be taken from top level pod'
                       properties:
                         allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN Note that this field cannot be set
+                            when spec.os.name is windows.'
                           type: boolean
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime. Note that this field cannot be
+                            set when spec.os.name is windows.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false. Note that this field
+                            cannot be set when spec.os.name is windows.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled. Note that this field cannot
+                            be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false. Note that this field cannot
+                            be set when spec.os.name is windows.
                           type: boolean
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence. Note
+                            that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is windows.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                            Note that this field cannot be set when spec.os.name is
+                            windows.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is
+                            linux.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     volumeMounts:
+                      description: 'Optional: volumes etc for the Druid pods'
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -234,22 +471,63 @@ spec:
                   type: object
                 type: array
               affinity:
+                description: 'Optional: affinity to be used to for enabling node,
+                  pod affinity and anti-affinity'
                 properties:
                   nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
                         items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
                           properties:
                             preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -259,13 +537,33 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -275,7 +573,10 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -284,18 +585,50 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -305,13 +638,33 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -321,28 +674,69 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -354,18 +748,54 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -377,18 +807,40 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -397,18 +849,52 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
                         items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
                           properties:
                             labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -420,18 +906,49 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is beta-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -443,13 +960,33 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -457,22 +994,62 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -484,18 +1061,54 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -507,18 +1120,40 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -527,18 +1162,52 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
                         items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
                           properties:
                             labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -550,18 +1219,49 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is beta-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -573,13 +1273,33 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -588,73 +1308,176 @@ spec:
                     type: object
                 type: object
               common.runtime.properties:
+                description: 'Required: common.runtime.properties contents'
                 type: string
               commonConfigMountPath:
+                description: 'Required: in-container directory to mount with common.runtime.properties'
                 type: string
               containerSecurityContext:
+                description: 'Optional: druid pods container-security-context'
                 properties:
                   allowPrivilegeEscalation:
+                    description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.'
                     type: boolean
                   capabilities:
+                    description: The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container
+                      runtime. Note that this field cannot be set when spec.os.name
+                      is windows.
                     properties:
                       add:
+                        description: Added capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                       drop:
+                        description: Removed capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                     type: object
                   privileged:
+                    description: Run container in privileged mode. Processes in privileged
+                      containers are essentially equivalent to root on the host. Defaults
+                      to false. Note that this field cannot be set when spec.os.name
+                      is windows.
                     type: boolean
                   procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers. The default is DefaultProcMount which uses the
+                      container runtime defaults for readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
+                    description: Whether this container has a read-only root filesystem.
+                      Default is false. Note that this field cannot be set when spec.os.name
+                      is windows.
                     type: boolean
                   runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence. Note that this field cannot be set when spec.os.name
+                      is windows.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by this container. If
+                      seccomp options are provided at both the pod & container level,
+                      the container options override the pod options. Note that this
+                      field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
                         type: string
                       type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will
+                      be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
                     properties:
                       gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
               deepStorage:
                 properties:
                   spec:
+                    description: RawMessage is a raw encoded JSON value. It implements
+                      Marshaler and Unmarshaler and can be used to delay JSON decoding
+                      or precompute a JSON encoding.
                     format: byte
                     type: string
                   type:
@@ -664,139 +1487,251 @@ spec:
                 - type
                 type: object
               deleteOrphanPvc:
+                description: 'Optional: Default is set to true, orphaned ( unmounted
+                  pvc''s ) shall be cleaned up by the operator.'
                 type: boolean
               disablePVCDeletionFinalizer:
+                description: 'Optional: Default is set to false, pvc shall be deleted
+                  on deletion of CR'
                 type: boolean
               env:
+                description: 'Optional: environment variables for druid containers'
                 items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
                       type: string
                     valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
+                              description: The key to select.
                               type: string
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
                           properties:
                             apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
+                          x-kubernetes-map-type: atomic
                         resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
                           properties:
                             containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
+                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
+                          x-kubernetes-map-type: atomic
                         secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                   required:
                   - name
                   type: object
                 type: array
               envFrom:
+                description: 'Optional: Extra environment variables'
                 items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
                   properties:
                     configMapRef:
+                      description: The ConfigMap to select from
                       properties:
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
+                          description: Specify whether the ConfigMap must be defined
                           type: boolean
                       type: object
+                      x-kubernetes-map-type: atomic
                     prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
                       type: string
                     secretRef:
+                      description: The Secret to select from
                       properties:
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
+                          description: Specify whether the Secret must be defined
                           type: boolean
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               forceDeleteStsPodOnError:
+                description: 'Optional: Default is true, will delete the sts pod if
+                  sts is set to ordered ready to ensure issue: https://github.com/kubernetes/kubernetes/issues/67250
+                  doc: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#forced-rollback'
                 type: boolean
               ignored:
+                description: 'Optional: If true, this spec would be ignored by the
+                  operator'
                 type: boolean
               image:
+                description: Required here or at nodeSpec level
                 type: string
               imagePullPolicy:
+                description: 'Optional:'
                 type: string
               imagePullSecrets:
+                description: 'Optional: imagePullSecrets for private registries'
                 items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 type: array
               jvm.options:
+                description: 'Optional: jvm options for druid jvm processes'
                 type: string
               livenessProbe:
+                description: Optional, port is set to druid.port if not specified
+                  with httpGet handler
                 properties:
                   exec:
+                    description: Exec specifies the action to take.
                     properties:
                       command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
                         items:
                           type: string
                         type: array
                     type: object
                   failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
                     format: int32
                     type: integer
                   grpc:
+                    description: GRPC specifies an action involving a GRPC port. This
+                      is an alpha field and requires enabling GRPCContainerProbe feature
+                      gate.
                     properties:
                       port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
+                        description: "Service is the name of the service to place
+                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                          \n If this is not specified, the default behavior is defined
+                          by gRPC."
                         type: string
                     required:
                     - port
                     type: object
                   httpGet:
+                    description: HTTPGet specifies the http request to perform.
                     properties:
                       host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
+                              description: The header field name
                               type: string
                             value:
+                              description: The header field value
                               type: string
                           required:
                           - name
@@ -804,50 +1739,88 @@ spec:
                           type: object
                         type: array
                       path:
+                        description: Path to access on the HTTP server.
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                       scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
                         type: string
                     required:
                     - port
                     type: object
                   initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
                   periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
                     format: int32
                     type: integer
                   successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
                     format: int32
                     type: integer
                   tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
                     properties:
                       host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                     required:
                     - port
                     type: object
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure. The grace period is the duration
+                      in seconds after the processes running in the pod are sent a
+                      termination signal and the time when the processes are forcibly
+                      halted with a kill signal. Set this value longer than the expected
+                      cleanup time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec. Value must
+                      be non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). This is a
+                      beta field and requires enabling ProbeTerminationGracePeriod
+                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                      is used if unset.
                     format: int64
                     type: integer
                   timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
                 type: object
               log4j.config:
+                description: 'Optional: log4j config contents'
                 type: string
               metadataStore:
                 properties:
                   spec:
+                    description: RawMessage is a raw encoded JSON value. It implements
+                      Marshaler and Unmarshaler and can be used to delay JSON decoding
+                      or precompute a JSON encoding.
                     format: byte
                     type: string
                   type:
@@ -857,31 +1830,76 @@ spec:
                 - type
                 type: object
               metricDimensions.json:
+                description: 'Optional: Custom Dimension Map Path for statsd emitter'
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: 'Optional: node selector to be used by Druid statefulsets'
                 type: object
               nodes:
                 additionalProperties:
                   properties:
                     affinity:
+                      description: 'Optional: affinity to be used to for enabling
+                        node, pod affinity and anti-affinity'
                       properties:
                         nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
                                 properties:
                                   preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: The label key that the
+                                                selector applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -891,13 +1909,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: The label key that the
+                                                selector applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -907,7 +1947,11 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -916,18 +1960,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
                               properties:
                                 nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: The label key that the
+                                                selector applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -937,13 +2016,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: The label key that the
+                                                selector applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -953,28 +2054,73 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                               - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -986,18 +2132,56 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is beta-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1009,18 +2193,44 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
                                         type: string
                                     required:
                                     - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1029,18 +2239,57 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1052,18 +2301,54 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces. This field
+                                      is beta-level and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1075,13 +2360,35 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
                                     type: string
                                 required:
                                 - topologyKey
@@ -1089,22 +2396,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1116,18 +2466,56 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is beta-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1139,18 +2527,44 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
                                         type: string
                                     required:
                                     - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1159,18 +2573,57 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1182,18 +2635,54 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces. This field
+                                      is beta-level and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1205,13 +2694,35 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
                                     type: string
                                 required:
                                 - topologyKey
@@ -1220,167 +2731,384 @@ spec:
                           type: object
                       type: object
                     containerSecurityContext:
+                      description: 'Optional: druid pods container-security-context'
                       properties:
                         allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN Note that this field cannot be set
+                            when spec.os.name is windows.'
                           type: boolean
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime. Note that this field cannot be
+                            set when spec.os.name is windows.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false. Note that this field
+                            cannot be set when spec.os.name is windows.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled. Note that this field cannot
+                            be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false. Note that this field cannot
+                            be set when spec.os.name is windows.
                           type: boolean
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence. Note
+                            that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is windows.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                            Note that this field cannot be set when spec.os.name is
+                            windows.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is
+                            linux.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     druid.port:
+                      description: 'Required: Port used by Druid Process'
                       format: int32
                       type: integer
                     env:
+                      description: 'Optional: Extra environment variables'
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
+                                x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                         required:
                         - name
                         type: object
                       type: array
                     envFrom:
+                      description: 'Optional: Extra environment variables'
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     extra.jvm.options:
+                      description: 'Optional: This appends extra jvm options to JvmOptions
+                        field'
                       type: string
                     hpAutoscaler:
+                      description: Optional
                       properties:
                         behavior:
+                          description: behavior configures the scaling behavior of
+                            the target in both Up and Down directions (scaleUp and
+                            scaleDown fields respectively). If not set, the default
+                            HPAScalingRules for scale up and scale down are used.
                           properties:
                             scaleDown:
+                              description: scaleDown is scaling policy for scaling
+                                Down. If not set, the default value is to allow to
+                                scale down to minReplicas pods, with a 300 second
+                                stabilization window (i.e., the highest recommendation
+                                for the last 300sec is used).
                               properties:
                                 policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
                                   items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
                                     properties:
                                       periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
                                         format: int32
                                         type: integer
                                       type:
+                                        description: Type is used to specify the scaling
+                                          policy.
                                         type: string
                                       value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
                                         format: int32
                                         type: integer
                                     required:
@@ -1390,22 +3118,55 @@ spec:
                                     type: object
                                   type: array
                                 selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
                                   type: string
                                 stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
                                   format: int32
                                   type: integer
                               type: object
                             scaleUp:
+                              description: 'scaleUp is scaling policy for scaling
+                                Up. If not set, the default value is the higher of:
+                                * increase no more than 4 pods per 60 seconds * double
+                                the number of pods per 60 seconds No stabilization
+                                is used.'
                               properties:
                                 policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
                                   items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
                                     properties:
                                       periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
                                         format: int32
                                         type: integer
                                       type:
+                                        description: Type is used to specify the scaling
+                                          policy.
                                         type: string
                                       value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
                                         format: int32
                                         type: integer
                                     required:
@@ -1415,41 +3176,98 @@ spec:
                                     type: object
                                   type: array
                                 selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
                                   type: string
                                 stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
                                   format: int32
                                   type: integer
                               type: object
                           type: object
                         maxReplicas:
+                          description: maxReplicas is the upper limit for the number
+                            of replicas to which the autoscaler can scale up. It cannot
+                            be less that minReplicas.
                           format: int32
                           type: integer
                         metrics:
+                          description: metrics contains the specifications for which
+                            to use to calculate the desired replica count (the maximum
+                            replica count across all metrics will be used).  The desired
+                            replica count is calculated multiplying the ratio between
+                            the target value and the current value by the current
+                            number of pods.  Ergo, metrics used must decrease as the
+                            pod count is increased, and vice-versa.  See the individual
+                            metric source types for more information about how each
+                            type of metric must respond. If not set, the default metric
+                            will be set to 80% average CPU utilization.
                           items:
+                            description: MetricSpec specifies how to scale based on
+                              a single metric (only `type` and one other matching
+                              field should be set at once).
                             properties:
                               containerResource:
+                                description: container resource refers to a resource
+                                  metric (such as those specified in requests and
+                                  limits) known to Kubernetes describing a single
+                                  container in each pod of the current scale target
+                                  (e.g. CPU or memory). Such metrics are built in
+                                  to Kubernetes, and have special scaling options
+                                  on top of those available to normal per-pod metrics
+                                  using the "pods" source. This is an alpha feature
+                                  and can be enabled by the HPAContainerMetrics feature
+                                  flag.
                                 properties:
                                   container:
+                                    description: container is the name of the container
+                                      in the pods of the scaling target
                                     type: string
                                   name:
+                                    description: name is the name of the resource
+                                      in question.
                                     type: string
                                   target:
+                                    description: target specifies the target value
+                                      for the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1461,21 +3279,59 @@ spec:
                                 - target
                                 type: object
                               external:
+                                description: external refers to a global metric that
+                                  is not associated with any Kubernetes object. It
+                                  allows autoscaling based on information coming from
+                                  components running outside of cluster (for example
+                                  length of queue in cloud messaging service, or QPS
+                                  from loadbalancer running outside of cluster).
                                 properties:
                                   metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
                                     properties:
                                       name:
+                                        description: name is the name of the given
+                                          metric
                                         type: string
                                       selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1487,28 +3343,50 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - name
                                     type: object
                                   target:
+                                    description: target specifies the target value
+                                      for the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1519,33 +3397,76 @@ spec:
                                 - target
                                 type: object
                               object:
+                                description: object refers to a metric describing
+                                  a single kubernetes object (for example, hits-per-second
+                                  on an Ingress object).
                                 properties:
                                   describedObject:
+                                    description: CrossVersionObjectReference contains
+                                      enough information to let you identify the referred
+                                      resource.
                                     properties:
                                       apiVersion:
+                                        description: API version of the referent
                                         type: string
                                       kind:
+                                        description: 'Kind of the referent; More info:
+                                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                         type: string
                                       name:
+                                        description: 'Name of the referent; More info:
+                                          http://kubernetes.io/docs/user-guide/identifiers#names'
                                         type: string
                                     required:
                                     - kind
                                     - name
                                     type: object
                                   metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
                                     properties:
                                       name:
+                                        description: name is the name of the given
+                                          metric
                                         type: string
                                       selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1557,28 +3478,50 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - name
                                     type: object
                                   target:
+                                    description: target specifies the target value
+                                      for the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1590,21 +3533,57 @@ spec:
                                 - target
                                 type: object
                               pods:
+                                description: pods refers to a metric describing each
+                                  pod in the current scale target (for example, transactions-processed-per-second).  The
+                                  values will be averaged together before being compared
+                                  to the target value.
                                 properties:
                                   metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
                                     properties:
                                       name:
+                                        description: name is the name of the given
+                                          metric
                                         type: string
                                       selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1616,28 +3595,50 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - name
                                     type: object
                                   target:
+                                    description: target specifies the target value
+                                      for the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1648,26 +3649,50 @@ spec:
                                 - target
                                 type: object
                               resource:
+                                description: resource refers to a resource metric
+                                  (such as those specified in requests and limits)
+                                  known to Kubernetes describing each pod in the current
+                                  scale target (e.g. CPU or memory). Such metrics
+                                  are built in to Kubernetes, and have special scaling
+                                  options on top of those available to normal per-pod
+                                  metrics using the "pods" source.
                                 properties:
                                   name:
+                                    description: name is the name of the resource
+                                      in question.
                                     type: string
                                   target:
+                                    description: target specifies the target value
+                                      for the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1678,21 +3703,40 @@ spec:
                                 - target
                                 type: object
                               type:
+                                description: 'type is the type of metric source.  It
+                                  should be one of "ContainerResource", "External",
+                                  "Object", "Pods" or "Resource", each mapping to
+                                  a matching field in the object. Note: "ContainerResource"
+                                  type is available on when the feature-gate HPAContainerMetrics
+                                  is enabled'
                                 type: string
                             required:
                             - type
                             type: object
                           type: array
                         minReplicas:
+                          description: minReplicas is the lower limit for the number
+                            of replicas to which the autoscaler can scale down.  It
+                            defaults to 1 pod.  minReplicas is allowed to be 0 if
+                            the alpha feature gate HPAScaleToZero is enabled and at
+                            least one Object or External metric is configured.  Scaling
+                            is active as long as at least one metric value is available.
                           format: int32
                           type: integer
                         scaleTargetRef:
+                          description: scaleTargetRef points to the target resource
+                            to scale, and is used to the pods for which metrics should
+                            be collected, as well as to actually change the replica
+                            count.
                           properties:
                             apiVersion:
+                              description: API version of the referent
                               type: string
                             kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                               type: string
                             name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string
                           required:
                           - kind
@@ -1703,41 +3747,85 @@ spec:
                       - scaleTargetRef
                       type: object
                     image:
+                      description: 'Optional: Overrides image from top level, Required
+                        if no image specified at top level'
                       type: string
                     imagePullPolicy:
+                      description: 'Optional: Overrides imagePullPolicy from top level'
                       type: string
                     imagePullSecrets:
+                      description: 'Optional: Overrides imagePullSecrets from top
+                        level'
                       items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
                           name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       type: array
                     ingress:
+                      description: 'Optional: Ingress Spec'
                       properties:
                         defaultBackend:
+                          description: DefaultBackend is the backend that should handle
+                            requests that don't match any rule. If Rules are not specified,
+                            DefaultBackend must be specified. If DefaultBackend is
+                            not set, the handling of requests that do not match any
+                            of the rules will be up to the Ingress controller.
                           properties:
                             resource:
+                              description: Resource is an ObjectRef to another Kubernetes
+                                resource in the namespace of the Ingress object. If
+                                resource is specified, a service.Name and service.Port
+                                must not be specified. This is a mutually exclusive
+                                setting with "Service".
                               properties:
                                 apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
+                                  description: Kind is the type of resource being
+                                    referenced
                                   type: string
                                 name:
+                                  description: Name is the name of resource being
+                                    referenced
                                   type: string
                               required:
                               - kind
                               - name
                               type: object
+                              x-kubernetes-map-type: atomic
                             service:
+                              description: Service references a Service as a Backend.
+                                This is a mutually exclusive setting with "Resource".
                               properties:
                                 name:
+                                  description: Name is the referenced service. The
+                                    service must exist in the same namespace as the
+                                    Ingress object.
                                   type: string
                                 port:
+                                  description: Port of the referenced service. A port
+                                    name or port number is required for a IngressServiceBackend.
                                   properties:
                                     name:
+                                      description: Name is the name of the port on
+                                        the Service. This is a mutually exclusive
+                                        setting with "Number".
                                       type: string
                                     number:
+                                      description: Number is the numerical port number
+                                        (e.g. 80) on the Service. This is a mutually
+                                        exclusive setting with "Name".
                                       format: int32
                                       type: integer
                                   type: object
@@ -1746,40 +3834,140 @@ spec:
                               type: object
                           type: object
                         ingressClassName:
+                          description: IngressClassName is the name of the IngressClass
+                            cluster resource. The associated IngressClass defines
+                            which controller will implement the resource. This replaces
+                            the deprecated `kubernetes.io/ingress.class` annotation.
+                            For backwards compatibility, when that annotation is set,
+                            it must be given precedence over this field. The controller
+                            may emit a warning if the field and annotation have different
+                            values. Implementations of this API should ignore Ingresses
+                            without a class specified. An IngressClass resource may
+                            be marked as default, which can be used to set a default
+                            value for this field. For more information, refer to the
+                            IngressClass documentation.
                           type: string
                         rules:
+                          description: A list of host rules used to configure the
+                            Ingress. If unspecified, or no rule matches, all traffic
+                            is sent to the default backend.
                           items:
+                            description: IngressRule represents the rules mapping
+                              the paths under a specified host to the related backend
+                              services. Incoming requests are first evaluated for
+                              a host match, then routed to the backend associated
+                              with the matching IngressRuleValue.
                             properties:
                               host:
+                                description: "Host is the fully qualified domain name
+                                  of a network host, as defined by RFC 3986. Note
+                                  the following deviations from the \"host\" part
+                                  of the URI as defined in RFC 3986: 1. IPs are not
+                                  allowed. Currently an IngressRuleValue can only
+                                  apply to the IP in the Spec of the parent Ingress.
+                                  2. The `:` delimiter is not respected because ports
+                                  are not allowed. Currently the port of an Ingress
+                                  is implicitly :80 for http and :443 for https. Both
+                                  these may change in the future. Incoming requests
+                                  are matched against the host before the IngressRuleValue.
+                                  If the host is unspecified, the Ingress routes all
+                                  traffic based on the specified IngressRuleValue.
+                                  \n Host can be \"precise\" which is a domain name
+                                  without the terminating dot of a network host (e.g.
+                                  \"foo.bar.com\") or \"wildcard\", which is a domain
+                                  name prefixed with a single wildcard label (e.g.
+                                  \"*.foo.com\"). The wildcard character '*' must
+                                  appear by itself as the first DNS label and matches
+                                  only a single label. You cannot have a wildcard
+                                  label by itself (e.g. Host == \"*\"). Requests will
+                                  be matched against the Host field in the following
+                                  way: 1. If Host is precise, the request matches
+                                  this rule if the http host header is equal to Host.
+                                  2. If Host is a wildcard, then the request matches
+                                  this rule if the http host header is to equal to
+                                  the suffix (removing the first label) of the wildcard
+                                  rule."
                                 type: string
                               http:
+                                description: 'HTTPIngressRuleValue is a list of http
+                                  selectors pointing to backends. In the example:
+                                  http://<host>/<path>?<searchpart> -> backend where
+                                  where parts of the url correspond to RFC 3986, this
+                                  resource will be used to match against everything
+                                  after the last ''/'' and before the first ''?''
+                                  or ''#''.'
                                 properties:
                                   paths:
+                                    description: A collection of paths that map requests
+                                      to backends.
                                     items:
+                                      description: HTTPIngressPath associates a path
+                                        with a backend. Incoming urls matching the
+                                        path are forwarded to the backend.
                                       properties:
                                         backend:
+                                          description: Backend defines the referenced
+                                            service endpoint to which the traffic
+                                            will be forwarded to.
                                           properties:
                                             resource:
+                                              description: Resource is an ObjectRef
+                                                to another Kubernetes resource in
+                                                the namespace of the Ingress object.
+                                                If resource is specified, a service.Name
+                                                and service.Port must not be specified.
+                                                This is a mutually exclusive setting
+                                                with "Service".
                                               properties:
                                                 apiGroup:
+                                                  description: APIGroup is the group
+                                                    for the resource being referenced.
+                                                    If APIGroup is not specified,
+                                                    the specified Kind must be in
+                                                    the core API group. For any other
+                                                    third-party types, APIGroup is
+                                                    required.
                                                   type: string
                                                 kind:
+                                                  description: Kind is the type of
+                                                    resource being referenced
                                                   type: string
                                                 name:
+                                                  description: Name is the name of
+                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             service:
+                                              description: Service references a Service
+                                                as a Backend. This is a mutually exclusive
+                                                setting with "Resource".
                                               properties:
                                                 name:
+                                                  description: Name is the referenced
+                                                    service. The service must exist
+                                                    in the same namespace as the Ingress
+                                                    object.
                                                   type: string
                                                 port:
+                                                  description: Port of the referenced
+                                                    service. A port name or port number
+                                                    is required for a IngressServiceBackend.
                                                   properties:
                                                     name:
+                                                      description: Name is the name
+                                                        of the port on the Service.
+                                                        This is a mutually exclusive
+                                                        setting with "Number".
                                                       type: string
                                                     number:
+                                                      description: Number is the numerical
+                                                        port number (e.g. 80) on the
+                                                        Service. This is a mutually
+                                                        exclusive setting with "Name".
                                                       format: int32
                                                       type: integer
                                                   type: object
@@ -1788,8 +3976,37 @@ spec:
                                               type: object
                                           type: object
                                         path:
+                                          description: Path is matched against the
+                                            path of an incoming request. Currently
+                                            it can contain characters disallowed from
+                                            the conventional "path" part of a URL
+                                            as defined by RFC 3986. Paths must begin
+                                            with a '/' and must be present when using
+                                            PathType with value "Exact" or "Prefix".
                                           type: string
                                         pathType:
+                                          description: 'PathType determines the interpretation
+                                            of the Path matching. PathType can be
+                                            one of the following values: * Exact:
+                                            Matches the URL path exactly. * Prefix:
+                                            Matches based on a URL path prefix split
+                                            by ''/''. Matching is done on a path element
+                                            by element basis. A path element refers
+                                            is the list of labels in the path split
+                                            by the ''/'' separator. A request is a
+                                            match for path p if every p is an element-wise
+                                            prefix of p of the request path. Note
+                                            that if the last element of the path is
+                                            a substring of the last element in request
+                                            path, it is not a match (e.g. /foo/bar
+                                            matches /foo/bar/baz, but does not match
+                                            /foo/barbaz). * ImplementationSpecific:
+                                            Interpretation of the Path matching is
+                                            up to the IngressClass. Implementations
+                                            can treat this as a separate PathType
+                                            or treat it identically to Prefix or Exact
+                                            path types. Implementations are required
+                                            to support all path types.'
                                           type: string
                                       required:
                                       - backend
@@ -1804,14 +4021,34 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         tls:
+                          description: TLS configuration. Currently the Ingress only
+                            supports a single TLS port, 443. If multiple members of
+                            this list specify different hosts, they will be multiplexed
+                            on the same port according to the hostname specified through
+                            the SNI TLS extension, if the ingress controller fulfilling
+                            the ingress supports SNI.
                           items:
+                            description: IngressTLS describes the transport layer
+                              security associated with an Ingress.
                             properties:
                               hosts:
+                                description: Hosts are a list of hosts included in
+                                  the TLS certificate. The values in this list must
+                                  match the name/s used in the tlsSecret. Defaults
+                                  to the wildcard host setting for the loadbalancer
+                                  controller fulfilling this Ingress, if left unspecified.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               secretName:
+                                description: SecretName is the name of the secret
+                                  used to terminate TLS traffic on port 443. Field
+                                  is left optional to allow TLS routing based on SNI
+                                  hostname alone. If the SNI host in a listener conflicts
+                                  with the "Host" header field used by an IngressRule,
+                                  the SNI host is used for termination and value of
+                                  the Host header is used for routing.
                                 type: string
                             type: object
                           type: array
@@ -1820,32 +4057,63 @@ spec:
                     ingressAnnotations:
                       additionalProperties:
                         type: string
+                      description: 'Optional: Ingress Annoatations to be populated
+                        in ingress spec'
                       type: object
                     jvm.options:
+                      description: 'Optional: This overrides JvmOptions at top level'
                       type: string
                     kind:
+                      description: 'Defaults to statefulsets. Note: volumeClaimTemplates
+                        are ignored when kind=Deployment'
                       type: string
                     lifecycle:
+                      description: Optional
                       properties:
                         postStart:
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
+                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: The header field name
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1853,49 +4121,95 @@ spec:
                                     type: object
                                   type: array
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
+                              description: Deprecated. TCPSocket is NOT supported
+                                as a LifecycleHandler and kept for the backward compatibility.
+                                There are no validation of this field and lifecycle
+                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The Pod''s termination grace period
+                            countdown begins before the PreStop hook is executed.
+                            Regardless of the outcome of the handler, the container
+                            will eventually terminate within the Pod''s termination
+                            grace period (unless delayed by finalizers). Other management
+                            of the container blocks until the hook completes or until
+                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
+                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: The header field name
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1903,25 +4217,40 @@ spec:
                                     type: object
                                   type: array
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
+                              description: Deprecated. TCPSocket is NOT supported
+                                as a LifecycleHandler and kept for the backward compatibility.
+                                There are no validation of this field and lifecycle
+                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -1929,37 +4258,69 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
+                      description: Optional
                       properties:
                         exec:
+                          description: Exec specifies the action to take.
                           properties:
                             command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                            This is an alpha field and requires enabling GRPCContainerProbe
+                            feature gate.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
+                              description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: The header field name
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1967,118 +4328,224 @@ spec:
                                 type: object
                               type: array
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     log4j.config:
+                      description: 'Optional: This overrides Log4jConfig at top level'
                       type: string
                     maxSurge:
+                      description: 'Optional: maxSurge for deployment object, only
+                        applicable if kind=Deployment'
                       format: int32
                       type: integer
                     maxUnavailable:
+                      description: 'Optional: maxUnavailable for deployment object,
+                        only applicable if kind=Deployment'
                       format: int32
                       type: integer
                     nodeConfigMountPath:
+                      description: 'Required: in-container directory to mount with
+                        runtime.properties, jvm.config, log4j2.xml files'
                       type: string
                     nodeSelector:
                       additionalProperties:
                         type: string
+                      description: 'Optional: node selector to be used by Druid statefulsets'
                       type: object
                     nodeType:
+                      description: 'Required: Druid node type e.g. Broker, Coordinator,
+                        Historical, MiddleManager, Router, Overlord etc'
                       type: string
                     persistentVolumeClaim:
+                      description: 'Optional: Persistant volume claim'
                       items:
+                        description: PersistentVolumeClaim is a user's request for
+                          and claim to a persistent volume
                         properties:
                           apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
                           kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
                           metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              finalizers:
-                                items:
-                                  type: string
-                                type: array
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              name:
-                                type: string
-                              namespace:
-                                type: string
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                             type: object
                           spec:
+                            description: 'Spec defines the desired characteristics
+                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             properties:
                               accessModes:
+                                description: 'AccessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
+                                description: 'This field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim) If the
+                                  provisioner or an external controller can support
+                                  the specified data source, it will create a new
+                                  volume based on the contents of the specified data
+                                  source. If the AnyVolumeDataSource feature gate
+                                  is enabled, this field will always have the same
+                                  contents as the DataSourceRef field.'
                                 properties:
                                   apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
                                     type: string
                                   kind:
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
+                                x-kubernetes-map-type: atomic
                               dataSourceRef:
+                                description: 'Specifies the object from which to populate
+                                  the volume with data, if a non-empty volume is desired.
+                                  This may be any local object from a non-empty API
+                                  group (non core object) or a PersistentVolumeClaim
+                                  object. When this field is specified, volume binding
+                                  will only succeed if the type of the specified object
+                                  matches some installed volume populator or dynamic
+                                  provisioner. This field will replace the functionality
+                                  of the DataSource field and as such if both fields
+                                  are non-empty, they must have the same value. For
+                                  backwards compatibility, both fields (DataSource
+                                  and DataSourceRef) will be set to the same value
+                                  automatically if one of them is empty and the other
+                                  is non-empty. There are two important differences
+                                  between DataSource and DataSourceRef: * While DataSource
+                                  only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim
+                                  objects. * While DataSource ignores disallowed values
+                                  (dropping them), DataSourceRef preserves all values,
+                                  and generates an error if a disallowed value is
+                                  specified. (Alpha) Using this field requires the
+                                  AnyVolumeDataSource feature gate to be enabled.'
                                 properties:
                                   apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
                                     type: string
                                   kind:
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resources:
+                                description: 'Resources represents the minimum resources
+                                  the volume should have. If RecoverVolumeExpansionFailure
+                                  feature is enabled users are allowed to specify
+                                  resource requirements that are lower than previous
+                                  value but must still be higher than capacity recorded
+                                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -2087,6 +4554,8 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2095,18 +4564,43 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
+                                description: A label query over volumes to consider
+                                  for binding.
                                 properties:
                                   matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
                                     items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
                                       properties:
                                         key:
+                                          description: key is the label key that the
+                                            selector applies to.
                                           type: string
                                         operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -2118,18 +4612,38 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               storageClassName:
+                                description: 'Name of the StorageClass required by
+                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                 type: string
                               volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim. Value of Filesystem is
+                                  implied when not included in claim spec.
                                 type: string
                               volumeName:
+                                description: VolumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           status:
+                            description: 'Status represents the current information/status
+                              of a persistent volume claim. Read-only. More info:
+                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             properties:
                               accessModes:
+                                description: 'AccessModes contains the actual access
+                                  modes the volume backing the PVC has. More info:
+                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
@@ -2140,6 +4654,19 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: The storage resource within AllocatedResources
+                                  tracks the capacity allocated to a PVC. It may be
+                                  larger than the actual capacity when a volume expansion
+                                  operation is requested. For storage quota, the larger
+                                  value from allocatedResources and PVC.spec.resources
+                                  is used. If allocatedResources is not set, PVC.spec.resources
+                                  alone is used for quota calculation. If a volume
+                                  expansion capacity request is lowered, allocatedResources
+                                  is only lowered if there are no expansion operations
+                                  in progress and if the actual volume capacity is
+                                  equal or lower than the requested capacity. This
+                                  is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                                  feature.
                                 type: object
                               capacity:
                                 additionalProperties:
@@ -2148,23 +4675,42 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Represents the actual resources of the
+                                  underlying volume.
                                 type: object
                               conditions:
+                                description: Current Condition of persistent volume
+                                  claim. If underlying persistent volume is being
+                                  resized then the Condition will be set to 'ResizeStarted'.
                                 items:
+                                  description: PersistentVolumeClaimCondition contails
+                                    details about state of pvc
                                   properties:
                                     lastProbeTime:
+                                      description: Last time we probed the condition.
                                       format: date-time
                                       type: string
                                     lastTransitionTime:
+                                      description: Last time the condition transitioned
+                                        from one status to another.
                                       format: date-time
                                       type: string
                                     message:
+                                      description: Human-readable message indicating
+                                        details about last transition.
                                       type: string
                                     reason:
+                                      description: Unique, this should be a short,
+                                        machine understandable string that gives the
+                                        reason for condition's last transition. If
+                                        it reports "ResizeStarted" that means the
+                                        underlying persistent volume is being resized.
                                       type: string
                                     status:
                                       type: string
                                     type:
+                                      description: PersistentVolumeClaimConditionType
+                                        is a valid value of PersistentVolumeClaimCondition.Type
                                       type: string
                                   required:
                                   - status
@@ -2172,8 +4718,16 @@ spec:
                                   type: object
                                 type: array
                               phase:
+                                description: Phase represents the current phase of
+                                  PersistentVolumeClaim.
                                 type: string
                               resizeStatus:
+                                description: ResizeStatus stores status of resize
+                                  operation. ResizeStatus is not set by default but
+                                  when expansion is complete resizeStatus is set to
+                                  empty string by resize controller or kubelet. This
+                                  is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                                  feature.
                                 type: string
                             type: object
                         type: object
@@ -2181,29 +4735,63 @@ spec:
                     podAnnotations:
                       additionalProperties:
                         type: string
+                      description: 'Optional: custom annotations to be populated in
+                        Druid pods'
                       type: object
                     podDisruptionBudgetSpec:
+                      description: Optional
                       properties:
                         maxUnavailable:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: An eviction is allowed if at most "maxUnavailable"
+                            pods selected by "selector" are unavailable after the
+                            eviction, i.e. even in absence of the evicted pod. For
+                            example, one can prevent all voluntary evictions by specifying
+                            0. This is a mutually exclusive setting with "minAvailable".
                           x-kubernetes-int-or-string: true
                         minAvailable:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: An eviction is allowed if at least "minAvailable"
+                            pods selected by "selector" will still be available after
+                            the eviction, i.e. even in the absence of the evicted
+                            pod.  So for example you can prevent all voluntary evictions
+                            by specifying "100%".
                           x-kubernetes-int-or-string: true
                         selector:
+                          description: Label query over pods whose evictions are managed
+                            by the disruption budget. A null selector selects no pods.
+                            An empty selector ({}) also selects no pods, which differs
+                            from standard behavior of selecting all pods. In policy/v1,
+                            an empty selector will select all pods in the namespace.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -2215,67 +4803,123 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                     podLabels:
                       additionalProperties:
                         type: string
+                      description: Optional
                       type: object
                     podManagementPolicy:
+                      description: 'Optional: By default it is set to "parallel"'
                       type: string
                     ports:
+                      description: 'Optional: extra ports to be added to pod spec'
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
                         type: object
                       type: array
                     readinessProbe:
+                      description: Optional
                       properties:
                         exec:
+                          description: Exec specifies the action to take.
                           properties:
                             command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                            This is an alpha field and requires enabling GRPCContainerProbe
+                            feature gate.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
+                              description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: The header field name
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -2283,50 +4927,91 @@ spec:
                                 type: object
                               type: array
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     replicas:
+                      description: Required
                       format: int32
                       minimum: 0
                       type: integer
                     resources:
+                      description: 'Optional: CPU/Memory Resources'
                       properties:
                         limits:
                           additionalProperties:
@@ -2335,6 +5020,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -2343,56 +5030,144 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     runtime.properties:
+                      description: Required
                       type: string
                     securityContext:
+                      description: 'Optional: Overrides securityContext at top level'
                       properties:
                         fsGroup:
+                          description: "A special supplemental group that applies
+                            to all containers in a pod. Some volume types allow the
+                            Kubelet to change the ownership of that volume to be owned
+                            by the pod: \n 1. The owning GID will be the FSGroup 2.
+                            The setgid bit is set (new files created in the volume
+                            will be owned by FSGroup) 3. The permission bits are OR'd
+                            with rw-rw---- \n If unset, the Kubelet will not modify
+                            the ownership and permissions of any volume. Note that
+                            this field cannot be set when spec.os.name is windows."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified, "Always"
+                            is used. Note that this field cannot be set when spec.os.name
+                            is windows.'
                           type: string
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence for
+                            that container. Note that this field cannot be set when
+                            spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod. Note that this field cannot be set when spec.os.name
+                            is windows.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container. Note that this field cannot be set when
+                            spec.os.name is windows.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch. Note that this field cannot
+                            be set when spec.os.name is windows.
                           items:
+                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
+                                description: Name of a property to set
                                 type: string
                               value:
+                                description: Value of a property to set
                                 type: string
                             required:
                             - name
@@ -2400,102 +5175,343 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is linux.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     services:
+                      description: 'Optional: Overrides services at top level'
                       items:
+                        description: Service is a named abstraction of software service
+                          (for example, mysql) consisting of local port (for example
+                          3306) that the proxy listens on, and the selector that determines
+                          which pods will answer requests sent through the proxy.
                         properties:
                           apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
                           kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
                           metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              finalizers:
-                                items:
-                                  type: string
-                                type: array
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              name:
-                                type: string
-                              namespace:
-                                type: string
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                             type: object
                           spec:
+                            description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                             properties:
                               allocateLoadBalancerNodePorts:
+                                description: allocateLoadBalancerNodePorts defines
+                                  if NodePorts will be automatically allocated for
+                                  services with type LoadBalancer.  Default is "true".
+                                  It may be set to "false" if the cluster load-balancer
+                                  does not rely on NodePorts.  If the caller requests
+                                  specific NodePorts (by specifying a value), those
+                                  requests will be respected, regardless of this field.
+                                  This field may only be set for services with type
+                                  LoadBalancer and will be cleared if the type is
+                                  changed to any other type. This field is beta-level
+                                  and is only honored by servers that enable the ServiceLBNodePortControl
+                                  feature.
                                 type: boolean
                               clusterIP:
+                                description: 'clusterIP is the IP address of the service
+                                  and is usually assigned randomly. If an address
+                                  is specified manually, is in-range (as per system
+                                  configuration), and is not in use, it will be allocated
+                                  to the service; otherwise creation of the service
+                                  will fail. This field may not be changed through
+                                  updates unless the type field is also being changed
+                                  to ExternalName (which requires this field to be
+                                  blank) or the type field is being changed from ExternalName
+                                  (in which case this field may optionally be specified,
+                                  as describe above).  Valid values are "None", empty
+                                  string (""), or a valid IP address. Setting this
+                                  to "None" makes a "headless service" (no virtual
+                                  IP), which is useful when direct endpoint connections
+                                  are preferred and proxying is not required.  Only
+                                  applies to types ClusterIP, NodePort, and LoadBalancer.
+                                  If this field is specified when creating a Service
+                                  of type ExternalName, creation will fail. This field
+                                  will be wiped when updating a Service to type ExternalName.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                                 type: string
                               clusterIPs:
+                                description: "ClusterIPs is a list of IP addresses
+                                  assigned to this service, and are usually assigned
+                                  randomly.  If an address is specified manually,
+                                  is in-range (as per system configuration), and is
+                                  not in use, it will be allocated to the service;
+                                  otherwise creation of the service will fail. This
+                                  field may not be changed through updates unless
+                                  the type field is also being changed to ExternalName
+                                  (which requires this field to be empty) or the type
+                                  field is being changed from ExternalName (in which
+                                  case this field may optionally be specified, as
+                                  describe above).  Valid values are \"None\", empty
+                                  string (\"\"), or a valid IP address.  Setting this
+                                  to \"None\" makes a \"headless service\" (no virtual
+                                  IP), which is useful when direct endpoint connections
+                                  are preferred and proxying is not required.  Only
+                                  applies to types ClusterIP, NodePort, and LoadBalancer.
+                                  If this field is specified when creating a Service
+                                  of type ExternalName, creation will fail. This field
+                                  will be wiped when updating a Service to type ExternalName.
+                                  \ If this field is not specified, it will be initialized
+                                  from the clusterIP field.  If this field is specified,
+                                  clients must ensure that clusterIPs[0] and clusterIP
+                                  have the same value. \n This field may hold a maximum
+                                  of two entries (dual-stack IPs, in either order).
+                                  These IPs must correspond to the values of the ipFamilies
+                                  field. Both clusterIPs and ipFamilies are governed
+                                  by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               externalIPs:
+                                description: externalIPs is a list of IP addresses
+                                  for which nodes in the cluster will also accept
+                                  traffic for this service.  These IPs are not managed
+                                  by Kubernetes.  The user is responsible for ensuring
+                                  that traffic arrives at a node with this IP.  A
+                                  common example is external load-balancers that are
+                                  not part of the Kubernetes system.
                                 items:
                                   type: string
                                 type: array
                               externalName:
+                                description: externalName is the external reference
+                                  that discovery mechanisms will return as an alias
+                                  for this service (e.g. a DNS CNAME record). No proxying
+                                  will be involved.  Must be a lowercase RFC-1123
+                                  hostname (https://tools.ietf.org/html/rfc1123) and
+                                  requires `type` to be "ExternalName".
                                 type: string
                               externalTrafficPolicy:
+                                description: externalTrafficPolicy denotes if this
+                                  Service desires to route external traffic to node-local
+                                  or cluster-wide endpoints. "Local" preserves the
+                                  client source IP and avoids a second hop for LoadBalancer
+                                  and Nodeport type services, but risks potentially
+                                  imbalanced traffic spreading. "Cluster" obscures
+                                  the client source IP and may cause a second hop
+                                  to another node, but should have good overall load-spreading.
                                 type: string
                               healthCheckNodePort:
+                                description: healthCheckNodePort specifies the healthcheck
+                                  nodePort for the service. This only applies when
+                                  type is set to LoadBalancer and externalTrafficPolicy
+                                  is set to Local. If a value is specified, is in-range,
+                                  and is not in use, it will be used.  If not specified,
+                                  a value will be automatically allocated.  External
+                                  systems (e.g. load-balancers) can use this port
+                                  to determine if a given node holds endpoints for
+                                  this service or not.  If this field is specified
+                                  when creating a Service which does not need it,
+                                  creation will fail. This field will be wiped when
+                                  updating a Service to no longer need it (e.g. changing
+                                  type).
                                 format: int32
                                 type: integer
                               internalTrafficPolicy:
+                                description: InternalTrafficPolicy specifies if the
+                                  cluster internal traffic should be routed to all
+                                  endpoints or node-local endpoints only. "Cluster"
+                                  routes internal traffic to a Service to all endpoints.
+                                  "Local" routes traffic to node-local endpoints only,
+                                  traffic is dropped if no node-local endpoints are
+                                  ready. The default value is "Cluster".
                                 type: string
                               ipFamilies:
+                                description: "IPFamilies is a list of IP families
+                                  (e.g. IPv4, IPv6) assigned to this service. This
+                                  field is usually assigned automatically based on
+                                  cluster configuration and the ipFamilyPolicy field.
+                                  If this field is specified manually, the requested
+                                  family is available in the cluster, and ipFamilyPolicy
+                                  allows it, it will be used; otherwise creation of
+                                  the service will fail. This field is conditionally
+                                  mutable: it allows for adding or removing a secondary
+                                  IP family, but it does not allow changing the primary
+                                  IP family of the Service. Valid values are \"IPv4\"
+                                  and \"IPv6\".  This field only applies to Services
+                                  of types ClusterIP, NodePort, and LoadBalancer,
+                                  and does apply to \"headless\" services. This field
+                                  will be wiped when updating a Service to type ExternalName.
+                                  \n This field may hold a maximum of two entries
+                                  (dual-stack families, in either order).  These families
+                                  must correspond to the values of the clusterIPs
+                                  field, if specified. Both clusterIPs and ipFamilies
+                                  are governed by the ipFamilyPolicy field."
                                 items:
+                                  description: IPFamily represents the IP Family (IPv4
+                                    or IPv6). This type is used to express the family
+                                    of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               ipFamilyPolicy:
+                                description: IPFamilyPolicy represents the dual-stack-ness
+                                  requested or required by this Service. If there
+                                  is no value provided, then this field will be set
+                                  to SingleStack. Services can be "SingleStack" (a
+                                  single IP family), "PreferDualStack" (two IP families
+                                  on dual-stack configured clusters or a single IP
+                                  family on single-stack clusters), or "RequireDualStack"
+                                  (two IP families on dual-stack configured clusters,
+                                  otherwise fail). The ipFamilies and clusterIPs fields
+                                  depend on the value of this field. This field will
+                                  be wiped when updating a service to type ExternalName.
                                 type: string
                               loadBalancerClass:
+                                description: loadBalancerClass is the class of the
+                                  load balancer implementation this Service belongs
+                                  to. If specified, the value of this field must be
+                                  a label-style identifier, with an optional prefix,
+                                  e.g. "internal-vip" or "example.com/internal-vip".
+                                  Unprefixed names are reserved for end-users. This
+                                  field can only be set when the Service type is 'LoadBalancer'.
+                                  If not set, the default load balancer implementation
+                                  is used, today this is typically done through the
+                                  cloud provider integration, but should apply for
+                                  any default implementation. If set, it is assumed
+                                  that a load balancer implementation is watching
+                                  for Services with a matching class. Any default
+                                  load balancer implementation (e.g. cloud providers)
+                                  should ignore Services that set this field. This
+                                  field can only be set when creating or updating
+                                  a Service to type 'LoadBalancer'. Once set, it can
+                                  not be changed. This field will be wiped when a
+                                  service is updated to a non 'LoadBalancer' type.
                                 type: string
                               loadBalancerIP:
+                                description: 'Only applies to Service Type: LoadBalancer
+                                  LoadBalancer will get created with the IP specified
+                                  in this field. This feature depends on whether the
+                                  underlying cloud-provider supports specifying the
+                                  loadBalancerIP when a load balancer is created.
+                                  This field will be ignored if the cloud-provider
+                                  does not support the feature.'
                                 type: string
                               loadBalancerSourceRanges:
+                                description: 'If specified and supported by the platform,
+                                  this will restrict traffic through the cloud-provider
+                                  load-balancer will be restricted to the specified
+                                  client IPs. This field will be ignored if the cloud-provider
+                                  does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
                                 items:
                                   type: string
                                 type: array
                               ports:
+                                description: 'The list of ports that are exposed by
+                                  this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                                 items:
+                                  description: ServicePort contains information on
+                                    service's port.
                                   properties:
                                     appProtocol:
+                                      description: The application protocol for this
+                                        port. This field follows standard Kubernetes
+                                        label syntax. Un-prefixed names are reserved
+                                        for IANA standard service names (as per RFC-6335
+                                        and http://www.iana.org/assignments/service-names).
+                                        Non-standard protocols should use prefixed
+                                        names such as mycompany.com/my-custom-protocol.
                                       type: string
                                     name:
+                                      description: The name of this port within the
+                                        service. This must be a DNS_LABEL. All ports
+                                        within a ServiceSpec must have unique names.
+                                        When considering the endpoints for a Service,
+                                        this must match the 'name' field in the EndpointPort.
+                                        Optional if only one ServicePort is defined
+                                        on this service.
                                       type: string
                                     nodePort:
+                                      description: 'The port on each node on which
+                                        this service is exposed when type is NodePort
+                                        or LoadBalancer.  Usually assigned by the
+                                        system. If a value is specified, in-range,
+                                        and not in use it will be used, otherwise
+                                        the operation will fail.  If not specified,
+                                        a port will be allocated if this Service requires
+                                        one.  If this field is specified when creating
+                                        a Service which does not need it, creation
+                                        will fail. This field will be wiped when updating
+                                        a Service to no longer need it (e.g. changing
+                                        type from NodePort to ClusterIP). More info:
+                                        https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
                                       format: int32
                                       type: integer
                                     port:
+                                      description: The port that will be exposed by
+                                        this service.
                                       format: int32
                                       type: integer
                                     protocol:
                                       default: TCP
+                                      description: The IP protocol for this port.
+                                        Supports "TCP", "UDP", and "SCTP". Default
+                                        is TCP.
                                       type: string
                                     targetPort:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: 'Number or name of the port to
+                                        access on the pods targeted by the service.
+                                        Number must be in the range 1 to 65535. Name
+                                        must be an IANA_SVC_NAME. If this is a string,
+                                        it will be looked up as a named port in the
+                                        target Pod''s container ports. If this is
+                                        not specified, the value of the ''port'' field
+                                        is used (an identity map). This field is ignored
+                                        for services with clusterIP=None, and should
+                                        be omitted or set equal to the ''port'' field.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
@@ -2506,53 +5522,152 @@ spec:
                                 - protocol
                                 x-kubernetes-list-type: map
                               publishNotReadyAddresses:
+                                description: publishNotReadyAddresses indicates that
+                                  any agent which deals with endpoints for this Service
+                                  should disregard any indications of ready/not-ready.
+                                  The primary use case for setting this field is for
+                                  a StatefulSet's Headless Service to propagate SRV
+                                  DNS records for its Pods for the purpose of peer
+                                  discovery. The Kubernetes controllers that generate
+                                  Endpoints and EndpointSlice resources for Services
+                                  interpret this to mean that all endpoints are considered
+                                  "ready" even if the Pods themselves are not. Agents
+                                  which consume only Kubernetes generated endpoints
+                                  through the Endpoints or EndpointSlice resources
+                                  can safely assume this behavior.
                                 type: boolean
                               selector:
                                 additionalProperties:
                                   type: string
+                                description: 'Route service traffic to pods with label
+                                  keys and values matching this selector. If empty
+                                  or not present, the service is assumed to have an
+                                  external process managing its endpoints, which Kubernetes
+                                  will not modify. Only applies to types ClusterIP,
+                                  NodePort, and LoadBalancer. Ignored if type is ExternalName.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                                 type: object
                                 x-kubernetes-map-type: atomic
                               sessionAffinity:
+                                description: 'Supports "ClientIP" and "None". Used
+                                  to maintain session affinity. Enable client IP based
+                                  session affinity. Must be ClientIP or None. Defaults
+                                  to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                                 type: string
                               sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations
+                                  of session affinity.
                                 properties:
                                   clientIP:
+                                    description: clientIP contains the configurations
+                                      of Client IP based session affinity.
                                     properties:
                                       timeoutSeconds:
+                                        description: timeoutSeconds specifies the
+                                          seconds of ClientIP type session sticky
+                                          time. The value must be >0 && <=86400(for
+                                          1 day) if ServiceAffinity == "ClientIP".
+                                          Default value is 10800(for 3 hours).
                                         format: int32
                                         type: integer
                                     type: object
                                 type: object
                               type:
+                                description: 'type determines how the Service is exposed.
+                                  Defaults to ClusterIP. Valid options are ExternalName,
+                                  ClusterIP, NodePort, and LoadBalancer. "ClusterIP"
+                                  allocates a cluster-internal IP address for load-balancing
+                                  to endpoints. Endpoints are determined by the selector
+                                  or if that is not specified, by manual construction
+                                  of an Endpoints object or EndpointSlice objects.
+                                  If clusterIP is "None", no virtual IP is allocated
+                                  and the endpoints are published as a set of endpoints
+                                  rather than a virtual IP. "NodePort" builds on ClusterIP
+                                  and allocates a port on every node which routes
+                                  to the same endpoints as the clusterIP. "LoadBalancer"
+                                  builds on NodePort and creates an external load-balancer
+                                  (if supported in the current cloud) which routes
+                                  to the same endpoints as the clusterIP. "ExternalName"
+                                  aliases this service to the specified externalName.
+                                  Several other fields do not apply to ExternalName
+                                  services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
                                 type: string
                             type: object
                           status:
+                            description: 'Most recently observed status of the service.
+                              Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                             properties:
                               conditions:
+                                description: Current service state
                                 items:
+                                  description: "Condition contains details for one
+                                    aspect of the current state of this API Resource.
+                                    --- This struct is intended for direct use as
+                                    an array at the field path .status.conditions.
+                                    \ For example, type FooStatus struct{ // Represents
+                                    the observations of a foo's current state. //
+                                    Known .status.conditions.type are: \"Available\",
+                                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type
+                                    // +patchStrategy=merge // +listType=map // +listMapKey=type
+                                    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                                    patchStrategy:\"merge\" patchMergeKey:\"type\"
+                                    protobuf:\"bytes,1,rep,name=conditions\"` \n //
+                                    other fields }"
                                   properties:
                                     lastTransitionTime:
+                                      description: lastTransitionTime is the last
+                                        time the condition transitioned from one status
+                                        to another. This should be when the underlying
+                                        condition changed.  If that is not known,
+                                        then using the time when the API field changed
+                                        is acceptable.
                                       format: date-time
                                       type: string
                                     message:
+                                      description: message is a human readable message
+                                        indicating details about the transition. This
+                                        may be an empty string.
                                       maxLength: 32768
                                       type: string
                                     observedGeneration:
+                                      description: observedGeneration represents the
+                                        .metadata.generation that the condition was
+                                        set based upon. For instance, if .metadata.generation
+                                        is currently 12, but the .status.conditions[x].observedGeneration
+                                        is 9, the condition is out of date with respect
+                                        to the current state of the instance.
                                       format: int64
                                       minimum: 0
                                       type: integer
                                     reason:
+                                      description: reason contains a programmatic
+                                        identifier indicating the reason for the condition's
+                                        last transition. Producers of specific condition
+                                        types may define expected values and meanings
+                                        for this field, and whether the values are
+                                        considered a guaranteed API. The value should
+                                        be a CamelCase string. This field may not
+                                        be empty.
                                       maxLength: 1024
                                       minLength: 1
                                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                                       type: string
                                     status:
+                                      description: status of the condition, one of
+                                        True, False, Unknown.
                                       enum:
                                       - "True"
                                       - "False"
                                       - Unknown
                                       type: string
                                     type:
+                                      description: type of condition in CamelCase
+                                        or in foo.example.com/CamelCase. --- Many
+                                        .condition.type values are consistent across
+                                        resources like Available, but because arbitrary
+                                        conditions can be useful (see .node.status.conditions),
+                                        the ability to deconflict is important. The
+                                        regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                       maxLength: 316
                                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                       type: string
@@ -2568,26 +5683,64 @@ spec:
                                 - type
                                 x-kubernetes-list-type: map
                               loadBalancer:
+                                description: LoadBalancer contains the current status
+                                  of the load-balancer, if one is present.
                                 properties:
                                   ingress:
+                                    description: Ingress is a list containing ingress
+                                      points for the load-balancer. Traffic intended
+                                      for the service should be sent to these ingress
+                                      points.
                                     items:
+                                      description: 'LoadBalancerIngress represents
+                                        the status of a load-balancer ingress point:
+                                        traffic intended for the service should be
+                                        sent to an ingress point.'
                                       properties:
                                         hostname:
+                                          description: Hostname is set for load-balancer
+                                            ingress points that are DNS based (typically
+                                            AWS load-balancers)
                                           type: string
                                         ip:
+                                          description: IP is set for load-balancer
+                                            ingress points that are IP based (typically
+                                            GCE or OpenStack load-balancers)
                                           type: string
                                         ports:
+                                          description: Ports is a list of records
+                                            of service ports If used, every port defined
+                                            in the service should have an entry in
+                                            it
                                           items:
                                             properties:
                                               error:
+                                                description: 'Error is to record the
+                                                  problem with the service port The
+                                                  format of the error shall comply
+                                                  with the following rules: - built-in
+                                                  error values shall be specified
+                                                  in this file and those shall use
+                                                  CamelCase names - cloud provider
+                                                  specific error values must have
+                                                  names that comply with the format
+                                                  foo.example.com/CamelCase. --- The
+                                                  regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
                                                 maxLength: 316
                                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                                 type: string
                                               port:
+                                                description: Port is the port number
+                                                  of the service port of which status
+                                                  is recorded here
                                                 format: int32
                                                 type: integer
                                               protocol:
                                                 default: TCP
+                                                description: 'Protocol is the protocol
+                                                  of the service port of which status
+                                                  is recorded here The supported values
+                                                  are: "TCP", "UDP", "SCTP"'
                                                 type: string
                                             required:
                                             - port
@@ -2602,37 +5755,69 @@ spec:
                         type: object
                       type: array
                     startUpProbes:
+                      description: 'Optional: StartupProbe for nodeSpec'
                       properties:
                         exec:
+                          description: Exec specifies the action to take.
                           properties:
                             command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                            This is an alpha field and requires enabling GRPCContainerProbe
+                            feature gate.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
+                              description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: The header field name
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -2640,77 +5825,166 @@ spec:
                                 type: object
                               type: array
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     terminationGracePeriodSeconds:
+                      description: 'Optional: terminationGracePeriod'
                       format: int64
                       type: integer
                     tolerations:
+                      description: 'Optional: toleration to be used in order to run
+                        Druid on nodes tainted'
                       items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
                             type: string
                           key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
                             type: string
                           operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
                             type: string
                           tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
+                      description: Optional
                       items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
                         properties:
                           labelSelector:
+                            description: LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine
+                              the number of pods in their corresponding topology domain.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -2722,14 +5996,58 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
                           maxSkew:
+                            description: 'MaxSkew describes the degree to which pods
+                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                              it is the maximum permitted difference between the number
+                              of matching pods in the target topology and the global
+                              minimum. For example, in a 3-zone cluster, MaxSkew is
+                              set to 1, and pods with the same labelSelector spread
+                              as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled
+                              to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                              would make the ActualSkew(2-0) on zone1(zone2) violate
+                              MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                              onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                              it is used to give higher precedence to topologies that
+                              satisfy it. It''s a required field. Default value is
+                              1 and 0 is not allowed.'
                             format: int32
                             type: integer
                           topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes
+                              that have a label with this key and identical values
+                              are considered to be in the same topology. We consider
+                              each <key, value> as a "bucket", and try to put balanced
+                              number of pods into each bucket. It's a required field.
                             type: string
                           whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal
+                              with a pod if it doesn''t satisfy the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to
+                              schedule it. - ScheduleAnyway tells the scheduler to
+                              schedule the pod in any location, but giving higher
+                              precedence to topologies that would help reduce the
+                              skew. A constraint is considered "Unsatisfiable" for
+                              an incoming pod if and only if every possible node assignment
+                              for that pod would violate "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to
+                              1, and pods with the same labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming
+                              pod can only be scheduled to zone2(zone3) to become
+                              3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be
+                              imbalanced, but scheduler won''t make it *more* imbalanced.
+                              It''s a required field.'
                             type: string
                         required:
                         - maxSkew
@@ -2738,73 +6056,137 @@ spec:
                         type: object
                       type: array
                     updateStrategy:
+                      description: Optional
                       properties:
                         rollingUpdate:
+                          description: RollingUpdate is used to communicate parameters
+                            when Type is RollingUpdateStatefulSetStrategyType.
                           properties:
                             partition:
+                              description: Partition indicates the ordinal at which
+                                the StatefulSet should be partitioned. Default value
+                                is 0.
                               format: int32
                               type: integer
                           type: object
                         type:
+                          description: Type indicates the type of the StatefulSetUpdateStrategy.
+                            Default is RollingUpdate.
                           type: string
                       type: object
                     volumeClaimTemplates:
                       items:
+                        description: PersistentVolumeClaim is a user's request for
+                          and claim to a persistent volume
                         properties:
                           apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
                           kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
                           metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              finalizers:
-                                items:
-                                  type: string
-                                type: array
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              name:
-                                type: string
-                              namespace:
-                                type: string
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                             type: object
                           spec:
+                            description: 'Spec defines the desired characteristics
+                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             properties:
                               accessModes:
+                                description: 'AccessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
+                                description: 'This field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim) If the
+                                  provisioner or an external controller can support
+                                  the specified data source, it will create a new
+                                  volume based on the contents of the specified data
+                                  source. If the AnyVolumeDataSource feature gate
+                                  is enabled, this field will always have the same
+                                  contents as the DataSourceRef field.'
                                 properties:
                                   apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
                                     type: string
                                   kind:
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
+                                x-kubernetes-map-type: atomic
                               dataSourceRef:
+                                description: 'Specifies the object from which to populate
+                                  the volume with data, if a non-empty volume is desired.
+                                  This may be any local object from a non-empty API
+                                  group (non core object) or a PersistentVolumeClaim
+                                  object. When this field is specified, volume binding
+                                  will only succeed if the type of the specified object
+                                  matches some installed volume populator or dynamic
+                                  provisioner. This field will replace the functionality
+                                  of the DataSource field and as such if both fields
+                                  are non-empty, they must have the same value. For
+                                  backwards compatibility, both fields (DataSource
+                                  and DataSourceRef) will be set to the same value
+                                  automatically if one of them is empty and the other
+                                  is non-empty. There are two important differences
+                                  between DataSource and DataSourceRef: * While DataSource
+                                  only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim
+                                  objects. * While DataSource ignores disallowed values
+                                  (dropping them), DataSourceRef preserves all values,
+                                  and generates an error if a disallowed value is
+                                  specified. (Alpha) Using this field requires the
+                                  AnyVolumeDataSource feature gate to be enabled.'
                                 properties:
                                   apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
                                     type: string
                                   kind:
+                                    description: Kind is the type of resource being
+                                      referenced
                                     type: string
                                   name:
+                                    description: Name is the name of resource being
+                                      referenced
                                     type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resources:
+                                description: 'Resources represents the minimum resources
+                                  the volume should have. If RecoverVolumeExpansionFailure
+                                  feature is enabled users are allowed to specify
+                                  resource requirements that are lower than previous
+                                  value but must still be higher than capacity recorded
+                                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -2813,6 +6195,8 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2821,18 +6205,43 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
+                                description: A label query over volumes to consider
+                                  for binding.
                                 properties:
                                   matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
                                     items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
                                       properties:
                                         key:
+                                          description: key is the label key that the
+                                            selector applies to.
                                           type: string
                                         operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -2844,18 +6253,38 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               storageClassName:
+                                description: 'Name of the StorageClass required by
+                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                 type: string
                               volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim. Value of Filesystem is
+                                  implied when not included in claim spec.
                                 type: string
                               volumeName:
+                                description: VolumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           status:
+                            description: 'Status represents the current information/status
+                              of a persistent volume claim. Read-only. More info:
+                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             properties:
                               accessModes:
+                                description: 'AccessModes contains the actual access
+                                  modes the volume backing the PVC has. More info:
+                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
@@ -2866,6 +6295,19 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: The storage resource within AllocatedResources
+                                  tracks the capacity allocated to a PVC. It may be
+                                  larger than the actual capacity when a volume expansion
+                                  operation is requested. For storage quota, the larger
+                                  value from allocatedResources and PVC.spec.resources
+                                  is used. If allocatedResources is not set, PVC.spec.resources
+                                  alone is used for quota calculation. If a volume
+                                  expansion capacity request is lowered, allocatedResources
+                                  is only lowered if there are no expansion operations
+                                  in progress and if the actual volume capacity is
+                                  equal or lower than the requested capacity. This
+                                  is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                                  feature.
                                 type: object
                               capacity:
                                 additionalProperties:
@@ -2874,23 +6316,42 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Represents the actual resources of the
+                                  underlying volume.
                                 type: object
                               conditions:
+                                description: Current Condition of persistent volume
+                                  claim. If underlying persistent volume is being
+                                  resized then the Condition will be set to 'ResizeStarted'.
                                 items:
+                                  description: PersistentVolumeClaimCondition contails
+                                    details about state of pvc
                                   properties:
                                     lastProbeTime:
+                                      description: Last time we probed the condition.
                                       format: date-time
                                       type: string
                                     lastTransitionTime:
+                                      description: Last time the condition transitioned
+                                        from one status to another.
                                       format: date-time
                                       type: string
                                     message:
+                                      description: Human-readable message indicating
+                                        details about last transition.
                                       type: string
                                     reason:
+                                      description: Unique, this should be a short,
+                                        machine understandable string that gives the
+                                        reason for condition's last transition. If
+                                        it reports "ResizeStarted" that means the
+                                        underlying persistent volume is being resized.
                                       type: string
                                     status:
                                       type: string
                                     type:
+                                      description: PersistentVolumeClaimConditionType
+                                        is a valid value of PersistentVolumeClaimCondition.Type
                                       type: string
                                   required:
                                   - status
@@ -2898,26 +6359,53 @@ spec:
                                   type: object
                                 type: array
                               phase:
+                                description: Phase represents the current phase of
+                                  PersistentVolumeClaim.
                                 type: string
                               resizeStatus:
+                                description: ResizeStatus stores status of resize
+                                  operation. ResizeStatus is not set by default but
+                                  when expansion is complete resizeStatus is set to
+                                  empty string by resize controller or kubelet. This
+                                  is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                                  feature.
                                 type: string
                             type: object
                         type: object
                       type: array
                     volumeMounts:
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -2926,103 +6414,230 @@ spec:
                       type: array
                     volumes:
                       items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
                         properties:
                           awsElasticBlockStore:
+                            description: 'AWSElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                             properties:
                               fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
                                 type: string
                               partition:
+                                description: 'The partition in the volume that you
+                                  want to mount. If omitted, the default is to mount
+                                  by volume name. Examples: For volume /dev/sda1,
+                                  you specify the partition as "1". Similarly, the
+                                  volume partition for /dev/sda is "0" (or you can
+                                  leave the property empty).'
                                 format: int32
                                 type: integer
                               readOnly:
+                                description: 'Specify "true" to force and set the
+                                  ReadOnly property in VolumeMounts to "true". If
+                                  omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                 type: boolean
                               volumeID:
+                                description: 'Unique ID of the persistent disk resource
+                                  in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                 type: string
                             required:
                             - volumeID
                             type: object
                           azureDisk:
+                            description: AzureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
                             properties:
                               cachingMode:
+                                description: 'Host Caching mode: None, Read Only,
+                                  Read Write.'
                                 type: string
                               diskName:
+                                description: The Name of the data disk in the blob
+                                  storage
                                 type: string
                               diskURI:
+                                description: The URI the data disk in the blob storage
                                 type: string
                               fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
                                 type: string
                               kind:
+                                description: 'Expected values Shared: multiple blob
+                                  disks per storage account  Dedicated: single blob
+                                  disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
                                 type: string
                               readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
                                 type: boolean
                             required:
                             - diskName
                             - diskURI
                             type: object
                           azureFile:
+                            description: AzureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
                             properties:
                               readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretName:
+                                description: the name of secret that contains Azure
+                                  Storage Account Name and Key
                                 type: string
                               shareName:
+                                description: Share Name
                                 type: string
                             required:
                             - secretName
                             - shareName
                             type: object
                           cephfs:
+                            description: CephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
                             properties:
                               monitors:
+                                description: 'Required: Monitors is a collection of
+                                  Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                 items:
                                   type: string
                                 type: array
                               path:
+                                description: 'Optional: Used as the mounted root,
+                                  rather than the full Ceph tree, default is /'
                                 type: string
                               readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                 type: boolean
                               secretFile:
+                                description: 'Optional: SecretFile is the path to
+                                  key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                 type: string
                               secretRef:
+                                description: 'Optional: SecretRef is reference to
+                                  the authentication secret for User, default is empty.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
+                                description: 'Optional: User is the rados user name,
+                                  default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                 type: string
                             required:
                             - monitors
                             type: object
                           cinder:
+                            description: 'Cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                             properties:
                               fsType:
+                                description: 'Filesystem type to mount. Must be a
+                                  filesystem type supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
                                 type: string
                               readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                 type: boolean
                               secretRef:
+                                description: 'Optional: points to a secret object
+                                  containing parameters used to connect to OpenStack.'
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeID:
+                                description: 'volume id used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                 type: string
                             required:
                             - volumeID
                             type: object
                           configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on created files by default. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. Defaults
+                                  to 0644. Directories within the path are not affected
+                                  by this setting. This might be in conflict with
+                                  other options that affect the file mode, like fsGroup,
+                                  and the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will
+                                  be projected into the volume as a file whose name
+                                  is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within
+                                    a volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file. Must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
                                       type: string
                                   required:
                                   - key
@@ -3030,137 +6645,336 @@ spec:
                                   type: object
                                 type: array
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap or its
+                                  keys must be defined
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           csi:
+                            description: CSI (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
                             properties:
                               driver:
+                                description: Driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
                                 type: string
                               fsType:
+                                description: Filesystem type to mount. Ex. "ext4",
+                                  "xfs", "ntfs". If not provided, the empty value
+                                  is passed to the associated CSI driver which will
+                                  determine the default filesystem to apply.
                                 type: string
                               nodePublishSecretRef:
+                                description: NodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               readOnly:
+                                description: Specifies a read-only configuration for
+                                  the volume. Defaults to false (read/write).
                                 type: boolean
                               volumeAttributes:
                                 additionalProperties:
                                   type: string
+                                description: VolumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
                                 type: object
                             required:
                             - driver
                             type: object
                           downwardAPI:
+                            description: DownwardAPI represents downward API about
+                              the pod that should populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a Optional: mode bits
+                                  used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: Items is a list of downward API volume
+                                  file
                                 items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
                                   properties:
                                     fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
                                       type: string
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   required:
                                   - path
                                   type: object
                                 type: array
                             type: object
                           emptyDir:
+                            description: 'EmptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                             properties:
                               medium:
+                                description: 'What type of storage medium should back
+                                  this directory. The default is "" which means to
+                                  use the node''s default medium. Must be an empty
+                                  string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                 type: string
                               sizeLimit:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: 'Total amount of local storage required
+                                  for this EmptyDir volume. The size limit is also
+                                  applicable for memory medium. The maximum usage
+                                  on memory medium EmptyDir would be the minimum value
+                                  between the SizeLimit specified here and the sum
+                                  of memory limits of all containers in a pod. The
+                                  default is nil which means that the limit is undefined.
+                                  More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                             type: object
                           ephemeral:
+                            description: "Ephemeral represents a volume that is handled
+                              by a cluster storage driver. The volume's lifecycle
+                              is tied to the pod that defines it - it will be created
+                              before the pod starts, and deleted when the pod is removed.
+                              \n Use this if: a) the volume is only needed while the
+                              pod runs, b) features of normal volumes like restoring
+                              from snapshot or capacity tracking are needed, c) the
+                              storage driver is specified through a storage class,
+                              and d) the storage driver supports dynamic volume provisioning
+                              through a PersistentVolumeClaim (see EphemeralVolumeSource
+                              for more information on the connection between this
+                              volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                              or one of the vendor-specific APIs for volumes that
+                              persist for longer than the lifecycle of an individual
+                              pod. \n Use CSI for light-weight local ephemeral volumes
+                              if the CSI driver is meant to be used that way - see
+                              the documentation of the driver for more information.
+                              \n A pod can use both types of ephemeral volumes and
+                              persistent volumes at the same time."
                             properties:
                               volumeClaimTemplate:
+                                description: "Will be used to create a stand-alone
+                                  PVC to provision the volume. The pod in which this
+                                  EphemeralVolumeSource is embedded will be the owner
+                                  of the PVC, i.e. the PVC will be deleted together
+                                  with the pod.  The name of the PVC will be `<pod
+                                  name>-<volume name>` where `<volume name>` is the
+                                  name from the `PodSpec.Volumes` array entry. Pod
+                                  validation will reject the pod if the concatenated
+                                  name is not valid for a PVC (for example, too long).
+                                  \n An existing PVC with that name that is not owned
+                                  by the pod will *not* be used for the pod to avoid
+                                  using an unrelated volume by mistake. Starting the
+                                  pod is then blocked until the unrelated PVC is removed.
+                                  If such a pre-created PVC is meant to be used by
+                                  the pod, the PVC has to updated with an owner reference
+                                  to the pod once the pod exists. Normally this should
+                                  not be necessary, but it may be useful when manually
+                                  reconstructing a broken cluster. \n This field is
+                                  read-only and no changes will be made by Kubernetes
+                                  to the PVC after it has been created. \n Required,
+                                  must not be nil."
                                 properties:
                                   metadata:
-                                    properties:
-                                      annotations:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      finalizers:
-                                        items:
-                                          type: string
-                                        type: array
-                                      labels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      name:
-                                        type: string
-                                      namespace:
-                                        type: string
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be
+                                      rejected during validation.
                                     type: object
                                   spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into
+                                      the PVC that gets created from this template.
+                                      The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
                                     properties:
                                       accessModes:
+                                        description: 'AccessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
+                                        description: 'This field can be used to specify
+                                          either: * An existing VolumeSnapshot object
+                                          (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller
+                                          can support the specified data source, it
+                                          will create a new volume based on the contents
+                                          of the specified data source. If the AnyVolumeDataSource
+                                          feature gate is enabled, this field will
+                                          always have the same contents as the DataSourceRef
+                                          field.'
                                         properties:
                                           apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
                                             type: string
                                           kind:
+                                            description: Kind is the type of resource
+                                              being referenced
                                             type: string
                                           name:
+                                            description: Name is the name of resource
+                                              being referenced
                                             type: string
                                         required:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
+                                        description: 'Specifies the object from which
+                                          to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any local
+                                          object from a non-empty API group (non core
+                                          object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding
+                                          will only succeed if the type of the specified
+                                          object matches some installed volume populator
+                                          or dynamic provisioner. This field will
+                                          replace the functionality of the DataSource
+                                          field and as such if both fields are non-empty,
+                                          they must have the same value. For backwards
+                                          compatibility, both fields (DataSource and
+                                          DataSourceRef) will be set to the same value
+                                          automatically if one of them is empty and
+                                          the other is non-empty. There are two important
+                                          differences between DataSource and DataSourceRef:
+                                          * While DataSource only allows two specific
+                                          types of objects, DataSourceRef allows any
+                                          non-core object, as well as PersistentVolumeClaim
+                                          objects. * While DataSource ignores disallowed
+                                          values (dropping them), DataSourceRef preserves
+                                          all values, and generates an error if a
+                                          disallowed value is specified. (Alpha) Using
+                                          this field requires the AnyVolumeDataSource
+                                          feature gate to be enabled.'
                                         properties:
                                           apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
                                             type: string
                                           kind:
+                                            description: Kind is the type of resource
+                                              being referenced
                                             type: string
                                           name:
+                                            description: Name is the name of resource
+                                              being referenced
                                             type: string
                                         required:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resources:
+                                        description: 'Resources represents the minimum
+                                          resources the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to
+                                          specify resource requirements that are lower
+                                          than previous value but must still be higher
+                                          than capacity recorded in the status field
+                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -3169,6 +6983,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -3177,18 +6994,47 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             type: object
                                         type: object
                                       selector:
+                                        description: A label query over volumes to
+                                          consider for binding.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -3200,13 +7046,28 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
+                                        description: 'Name of the StorageClass required
+                                          by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                         type: string
                                       volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec.
                                         type: string
                                       volumeName:
+                                        description: VolumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                 required:
@@ -3214,125 +7075,265 @@ spec:
                                 type: object
                             type: object
                           fc:
+                            description: FC represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
                             properties:
                               fsType:
+                                description: 'Filesystem type to mount. Must be a
+                                  filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. TODO: how do we prevent
+                                  errors in the filesystem from compromising the machine'
                                 type: string
                               lun:
+                                description: 'Optional: FC target lun number'
                                 format: int32
                                 type: integer
                               readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.'
                                 type: boolean
                               targetWWNs:
+                                description: 'Optional: FC target worldwide names
+                                  (WWNs)'
                                 items:
                                   type: string
                                 type: array
                               wwids:
+                                description: 'Optional: FC volume world wide identifiers
+                                  (wwids) Either wwids or combination of targetWWNs
+                                  and lun must be set, but not both simultaneously.'
                                 items:
                                   type: string
                                 type: array
                             type: object
                           flexVolume:
+                            description: FlexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
                             properties:
                               driver:
+                                description: Driver is the name of the driver to use
+                                  for this volume.
                                 type: string
                               fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". The default filesystem depends
+                                  on FlexVolume script.
                                 type: string
                               options:
                                 additionalProperties:
                                   type: string
+                                description: 'Optional: Extra command options if any.'
                                 type: object
                               readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.'
                                 type: boolean
                               secretRef:
+                                description: 'Optional: SecretRef is reference to
+                                  the secret object containing sensitive information
+                                  to pass to the plugin scripts. This may be empty
+                                  if no secret object is specified. If the secret
+                                  object contains more than one secret, all secrets
+                                  are passed to the plugin scripts.'
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                             - driver
                             type: object
                           flocker:
+                            description: Flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
                             properties:
                               datasetName:
+                                description: Name of the dataset stored as metadata
+                                  -> name on the dataset for Flocker should be considered
+                                  as deprecated
                                 type: string
                               datasetUUID:
+                                description: UUID of the dataset. This is unique identifier
+                                  of a Flocker dataset
                                 type: string
                             type: object
                           gcePersistentDisk:
+                            description: 'GCEPersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                             properties:
                               fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
                                 type: string
                               partition:
+                                description: 'The partition in the volume that you
+                                  want to mount. If omitted, the default is to mount
+                                  by volume name. Examples: For volume /dev/sda1,
+                                  you specify the partition as "1". Similarly, the
+                                  volume partition for /dev/sda is "0" (or you can
+                                  leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                 format: int32
                                 type: integer
                               pdName:
+                                description: 'Unique name of the PD resource in GCE.
+                                  Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                 type: string
                               readOnly:
+                                description: 'ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                 type: boolean
                             required:
                             - pdName
                             type: object
                           gitRepo:
+                            description: 'GitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
                             properties:
                               directory:
+                                description: Target directory name. Must not contain
+                                  or start with '..'.  If '.' is supplied, the volume
+                                  directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
                                 type: string
                               repository:
+                                description: Repository URL
                                 type: string
                               revision:
+                                description: Commit hash for the specified revision.
                                 type: string
                             required:
                             - repository
                             type: object
                           glusterfs:
+                            description: 'Glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                             properties:
                               endpoints:
+                                description: 'EndpointsName is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                 type: string
                               path:
+                                description: 'Path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                 type: string
                               readOnly:
+                                description: 'ReadOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                 type: boolean
                             required:
                             - endpoints
                             - path
                             type: object
                           hostPath:
+                            description: 'HostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              --- TODO(jonesdl) We need to restrict who can use host
+                              directory mounts and who can/can not mount host directories
+                              as read/write.'
                             properties:
                               path:
+                                description: 'Path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                 type: string
                               type:
+                                description: 'Type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                 type: string
                             required:
                             - path
                             type: object
                           iscsi:
+                            description: 'ISCSI represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                             properties:
                               chapAuthDiscovery:
+                                description: whether support iSCSI Discovery CHAP
+                                  authentication
                                 type: boolean
                               chapAuthSession:
+                                description: whether support iSCSI Session CHAP authentication
                                 type: boolean
                               fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
                                 type: string
                               initiatorName:
+                                description: Custom iSCSI Initiator Name. If initiatorName
+                                  is specified with iscsiInterface simultaneously,
+                                  new iSCSI interface <target portal>:<volume name>
+                                  will be created for the connection.
                                 type: string
                               iqn:
+                                description: Target iSCSI Qualified Name.
                                 type: string
                               iscsiInterface:
+                                description: iSCSI Interface Name that uses an iSCSI
+                                  transport. Defaults to 'default' (tcp).
                                 type: string
                               lun:
+                                description: iSCSI Target Lun number.
                                 format: int32
                                 type: integer
                               portals:
+                                description: iSCSI Target Portal List. The portal
+                                  is either an IP or ip_addr:port if the port is other
+                                  than default (typically TCP ports 860 and 3260).
                                 items:
                                   type: string
                                 type: array
                               readOnly:
+                                description: ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
                                 type: boolean
                               secretRef:
+                                description: CHAP Secret for iSCSI target and initiator
+                                  authentication
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               targetPortal:
+                                description: iSCSI Target Portal. The Portal is either
+                                  an IP or ip_addr:port if the port is other than
+                                  default (typically TCP ports 860 and 3260).
                                 type: string
                             required:
                             - iqn
@@ -3340,67 +7341,154 @@ spec:
                             - targetPortal
                             type: object
                           name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and
+                              unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           nfs:
+                            description: 'NFS represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                             properties:
                               path:
+                                description: 'Path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                 type: string
                               readOnly:
+                                description: 'ReadOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                 type: boolean
                               server:
+                                description: 'Server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                 type: string
                             required:
                             - path
                             - server
                             type: object
                           persistentVolumeClaim:
+                            description: 'PersistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                             properties:
                               claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 type: string
                               readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
                                 type: boolean
                             required:
                             - claimName
                             type: object
                           photonPersistentDisk:
+                            description: PhotonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
                             properties:
                               fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
                                 type: string
                               pdID:
+                                description: ID that identifies Photon Controller
+                                  persistent disk
                                 type: string
                             required:
                             - pdID
                             type: object
                           portworxVolume:
+                            description: PortworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
                             properties:
                               fsType:
+                                description: FSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
                                 type: string
                               readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               volumeID:
+                                description: VolumeID uniquely identifies a Portworx
+                                  volume
                                 type: string
                             required:
                             - volumeID
                             type: object
                           projected:
+                            description: Items for all in one resources secrets, configmaps,
+                              and downward API
                             properties:
                               defaultMode:
+                                description: Mode bits used to set permissions on
+                                  created files by default. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.
                                 format: int32
                                 type: integer
                               sources:
+                                description: list of volume projections
                                 items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
                                   properties:
                                     configMap:
+                                      description: information about the configMap
+                                        data to project
                                       properties:
                                         items:
+                                          description: If unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed
+                                            keys will be projected into the specified
+                                            paths, and unlisted keys will not be present.
+                                            If a key is specified which is not present
+                                            in the ConfigMap, the volume setup will
+                                            error unless it is marked optional. Paths
+                                            must be relative and may not contain the
+                                            '..' path or start with '..'.
                                           items:
+                                            description: Maps a string key to a path
+                                              within a volume.
                                             properties:
                                               key:
+                                                description: The key to project.
                                                 type: string
                                               mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file. Must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
+                                                description: The relative path of
+                                                  the file to map the key to. May
+                                                  not be an absolute path. May not
+                                                  contain the path element '..'. May
+                                                  not start with the string '..'.
                                                 type: string
                                             required:
                                             - key
@@ -3408,60 +7496,153 @@ spec:
                                             type: object
                                           type: array
                                         name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its keys must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     downwardAPI:
+                                      description: information about the downwardAPI
+                                        data to project
                                       properties:
                                         items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
                                           items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
                                             properties:
                                               fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
                                                 properties:
                                                   apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
                                                 type: string
                                               resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
                                                 properties:
                                                   containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
+                                                    description: 'Required: resource
+                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                             - path
                                             type: object
                                           type: array
                                       type: object
                                     secret:
+                                      description: information about the secret data
+                                        to project
                                       properties:
                                         items:
+                                          description: If unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            Secret will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed
+                                            keys will be projected into the specified
+                                            paths, and unlisted keys will not be present.
+                                            If a key is specified which is not present
+                                            in the Secret, the volume setup will error
+                                            unless it is marked optional. Paths must
+                                            be relative and may not contain the '..'
+                                            path or start with '..'.
                                           items:
+                                            description: Maps a string key to a path
+                                              within a volume.
                                             properties:
                                               key:
+                                                description: The key to project.
                                                 type: string
                                               mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file. Must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
+                                                description: The relative path of
+                                                  the file to map the key to. May
+                                                  not be an absolute path. May not
+                                                  contain the path element '..'. May
+                                                  not start with the string '..'.
                                                 type: string
                                             required:
                                             - key
@@ -3469,18 +7650,46 @@ spec:
                                             type: object
                                           type: array
                                         name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     serviceAccountToken:
+                                      description: information about the serviceAccountToken
+                                        data to project
                                       properties:
                                         audience:
+                                          description: Audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
                                           type: string
                                         expirationSeconds:
+                                          description: ExpirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
                                           format: int64
                                           type: integer
                                         path:
+                                          description: Path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
                                           type: string
                                       required:
                                       - path
@@ -3489,74 +7698,154 @@ spec:
                                 type: array
                             type: object
                           quobyte:
+                            description: Quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
                             properties:
                               group:
+                                description: Group to map volume access to Default
+                                  is no group
                                 type: string
                               readOnly:
+                                description: ReadOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
                                 type: boolean
                               registry:
+                                description: Registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
                                 type: string
                               tenant:
+                                description: Tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
                                 type: string
                               user:
+                                description: User to map volume access to Defaults
+                                  to serivceaccount user
                                 type: string
                               volume:
+                                description: Volume is a string that references an
+                                  already created Quobyte volume by name.
                                 type: string
                             required:
                             - registry
                             - volume
                             type: object
                           rbd:
+                            description: 'RBD represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
                             properties:
                               fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
                                 type: string
                               image:
+                                description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 type: string
                               keyring:
+                                description: 'Keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 type: string
                               monitors:
+                                description: 'A collection of Ceph monitors. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 items:
                                   type: string
                                 type: array
                               pool:
+                                description: 'The rados pool name. Default is rbd.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 type: string
                               readOnly:
+                                description: 'ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 type: boolean
                               secretRef:
+                                description: 'SecretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
+                                description: 'The rados user name. Default is admin.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                 type: string
                             required:
                             - image
                             - monitors
                             type: object
                           scaleIO:
+                            description: ScaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
                             properties:
                               fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Default is "xfs".
                                 type: string
                               gateway:
+                                description: The host address of the ScaleIO API Gateway.
                                 type: string
                               protectionDomain:
+                                description: The name of the ScaleIO Protection Domain
+                                  for the configured storage.
                                 type: string
                               readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
+                                description: SecretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               sslEnabled:
+                                description: Flag to enable/disable SSL communication
+                                  with Gateway, default false
                                 type: boolean
                               storageMode:
+                                description: Indicates whether the storage for a volume
+                                  should be ThickProvisioned or ThinProvisioned. Default
+                                  is ThinProvisioned.
                                 type: string
                               storagePool:
+                                description: The ScaleIO Storage Pool associated with
+                                  the protection domain.
                                 type: string
                               system:
+                                description: The name of the storage system as configured
+                                  in ScaleIO.
                                 type: string
                               volumeName:
+                                description: The name of a volume already created
+                                  in the ScaleIO system that is associated with this
+                                  volume source.
                                 type: string
                             required:
                             - gateway
@@ -3564,19 +7853,57 @@ spec:
                             - system
                             type: object
                           secret:
+                            description: 'Secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on created files by default. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. Defaults
+                                  to 0644. Directories within the path are not affected
+                                  by this setting. This might be in conflict with
+                                  other options that affect the file mode, like fsGroup,
+                                  and the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within
+                                    a volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file. Must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
                                       type: string
                                   required:
                                   - key
@@ -3584,35 +7911,78 @@ spec:
                                   type: object
                                 type: array
                               optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
                                 type: boolean
                               secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                  to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                           storageos:
+                            description: StorageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
                             properties:
                               fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
                                 type: string
                               readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
+                                description: SecretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
                                 properties:
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeName:
+                                description: VolumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
                                 type: string
                               volumeNamespace:
+                                description: VolumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
                                 type: string
                             type: object
                           vsphereVolume:
+                            description: VsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
                             properties:
                               fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
                                 type: string
                               storagePolicyID:
+                                description: Storage Policy Based Management (SPBM)
+                                  profile ID associated with the StoragePolicyName.
                                 type: string
                               storagePolicyName:
+                                description: Storage Policy Based Management (SPBM)
+                                  profile name.
                                 type: string
                               volumePath:
+                                description: Path that identifies vSphere volume vmdk
                                 type: string
                             required:
                             - volumePath
@@ -3628,49 +7998,91 @@ spec:
                   - replicas
                   - runtime.properties
                   type: object
+                description: Spec used to create StatefulSet specs etc, Many of the
+                  fields above can be overridden at the specific node spec level.
+                  Key in following map can be arbitrary string that helps you identify
+                  resources(pods, statefulsets etc) for specific nodeSpec. But, it
+                  is used in the k8s resource names, so it must be compliant with
+                  restrictions placed on k8s resource names. that is, it must match
+                  regex '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
                 type: object
               podAnnotations:
                 additionalProperties:
                   type: string
+                description: 'Optional: custom annotations to be populated in Druid
+                  pods'
                 type: object
               podLabels:
                 additionalProperties:
                   type: string
+                description: 'Optional: custom labels to be populated in Druid pods'
                 type: object
               podManagementPolicy:
+                description: 'Optional: By default it is set to "parallel"'
                 type: string
               readinessProbe:
+                description: Optional, port is set to druid.port if not specified
+                  with httpGet handler
                 properties:
                   exec:
+                    description: Exec specifies the action to take.
                     properties:
                       command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
                         items:
                           type: string
                         type: array
                     type: object
                   failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
                     format: int32
                     type: integer
                   grpc:
+                    description: GRPC specifies an action involving a GRPC port. This
+                      is an alpha field and requires enabling GRPCContainerProbe feature
+                      gate.
                     properties:
                       port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
+                        description: "Service is the name of the service to place
+                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                          \n If this is not specified, the default behavior is defined
+                          by gRPC."
                         type: string
                     required:
                     - port
                     type: object
                   httpGet:
+                    description: HTTPGet specifies the http request to perform.
                     properties:
                       host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
+                              description: The header field name
                               type: string
                             value:
+                              description: The header field value
                               type: string
                           required:
                           - name
@@ -3678,95 +8090,210 @@ spec:
                           type: object
                         type: array
                       path:
+                        description: Path to access on the HTTP server.
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                       scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
                         type: string
                     required:
                     - port
                     type: object
                   initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
                   periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
                     format: int32
                     type: integer
                   successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
                     format: int32
                     type: integer
                   tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
                     properties:
                       host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                     required:
                     - port
                     type: object
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure. The grace period is the duration
+                      in seconds after the processes running in the pod are sent a
+                      termination signal and the time when the processes are forcibly
+                      halted with a kill signal. Set this value longer than the expected
+                      cleanup time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec. Value must
+                      be non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). This is a
+                      beta field and requires enabling ProbeTerminationGracePeriod
+                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                      is used if unset.
                     format: int64
                     type: integer
                   timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
                 type: object
               rollingDeploy:
+                description: 'Operator deploys above list of nodes in the Druid prescribed
+                  order of Historical, Overlord, MiddleManager, Broker, Coordinator
+                  etc. Optional: If set to true then operator checks the rollout status
+                  of previous version StateSets before updating next. Used only for
+                  updates.'
                 type: boolean
               scalePvcSts:
+                description: 'Optional: ScalePvcSts, defaults to false. When enabled,
+                  operator will allow volume expansion of sts and pvc''s.'
                 type: boolean
               securityContext:
+                description: 'Optional: druid pods pod-security-context'
                 properties:
                   fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
                     type: string
                   runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
                         type: string
                       type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
                     items:
                       format: int64
                       type: integer
                     type: array
                   sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
                     items:
+                      description: Sysctl defines a kernel parameter to be set
                       properties:
                         name:
+                          description: Name of a property to set
                           type: string
                         value:
+                          description: Value of a property to set
                           type: string
                       required:
                       - name
@@ -3774,104 +8301,320 @@ spec:
                       type: object
                     type: array
                   windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
                     properties:
                       gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
               serviceAccount:
+                description: 'Optional: ServiceAccount for the druid cluster'
                 type: string
               services:
+                description: 'Optional: k8s service resources to be created for each
+                  Druid statefulsets'
                 items:
+                  description: Service is a named abstraction of software service
+                    (for example, mysql) consisting of local port (for example 3306)
+                    that the proxy listens on, and the selector that determines which
+                    pods will answer requests sent through the proxy.
                   properties:
                     apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                       type: string
                     kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                       type: string
                     metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        finalizers:
-                          items:
-                            type: string
-                          type: array
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        name:
-                          type: string
-                        namespace:
-                          type: string
+                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                       type: object
                     spec:
+                      description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                       properties:
                         allocateLoadBalancerNodePorts:
+                          description: allocateLoadBalancerNodePorts defines if NodePorts
+                            will be automatically allocated for services with type
+                            LoadBalancer.  Default is "true". It may be set to "false"
+                            if the cluster load-balancer does not rely on NodePorts.  If
+                            the caller requests specific NodePorts (by specifying
+                            a value), those requests will be respected, regardless
+                            of this field. This field may only be set for services
+                            with type LoadBalancer and will be cleared if the type
+                            is changed to any other type. This field is beta-level
+                            and is only honored by servers that enable the ServiceLBNodePortControl
+                            feature.
                           type: boolean
                         clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly. If an address is specified
+                            manually, is in-range (as per system configuration), and
+                            is not in use, it will be allocated to the service; otherwise
+                            creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also
+                            being changed to ExternalName (which requires this field
+                            to be blank) or the type field is being changed from ExternalName
+                            (in which case this field may optionally be specified,
+                            as describe above).  Valid values are "None", empty string
+                            (""), or a valid IP address. Setting this to "None" makes
+                            a "headless service" (no virtual IP), which is useful
+                            when direct endpoint connections are preferred and proxying
+                            is not required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                           type: string
                         clusterIPs:
+                          description: "ClusterIPs is a list of IP addresses assigned
+                            to this service, and are usually assigned randomly.  If
+                            an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated
+                            to the service; otherwise creation of the service will
+                            fail. This field may not be changed through updates unless
+                            the type field is also being changed to ExternalName (which
+                            requires this field to be empty) or the type field is
+                            being changed from ExternalName (in which case this field
+                            may optionally be specified, as describe above).  Valid
+                            values are \"None\", empty string (\"\"), or a valid IP
+                            address.  Setting this to \"None\" makes a \"headless
+                            service\" (no virtual IP), which is useful when direct
+                            endpoint connections are preferred and proxying is not
+                            required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            \ If this field is not specified, it will be initialized
+                            from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have
+                            the same value. \n This field may hold a maximum of two
+                            entries (dual-stack IPs, in either order). These IPs must
+                            correspond to the values of the ipFamilies field. Both
+                            clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
                           items:
                             type: string
                           type: array
                         externalName:
+                          description: externalName is the external reference that
+                            discovery mechanisms will return as an alias for this
+                            service (e.g. a DNS CNAME record). No proxying will be
+                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires `type` to be "ExternalName".
                           type: string
                         externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
                           type: string
                         healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. This only applies when type
+                            is set to LoadBalancer and externalTrafficPolicy is set
+                            to Local. If a value is specified, is in-range, and is
+                            not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g.
+                            load-balancers) can use this port to determine if a given
+                            node holds endpoints for this service or not.  If this
+                            field is specified when creating a Service which does
+                            not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing
+                            type).
                           format: int32
                           type: integer
                         internalTrafficPolicy:
+                          description: InternalTrafficPolicy specifies if the cluster
+                            internal traffic should be routed to all endpoints or
+                            node-local endpoints only. "Cluster" routes internal traffic
+                            to a Service to all endpoints. "Local" routes traffic
+                            to node-local endpoints only, traffic is dropped if no
+                            node-local endpoints are ready. The default value is "Cluster".
                           type: string
                         ipFamilies:
+                          description: "IPFamilies is a list of IP families (e.g.
+                            IPv4, IPv6) assigned to this service. This field is usually
+                            assigned automatically based on cluster configuration
+                            and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise
+                            creation of the service will fail. This field is conditionally
+                            mutable: it allows for adding or removing a secondary
+                            IP family, but it does not allow changing the primary
+                            IP family of the Service. Valid values are \"IPv4\" and
+                            \"IPv6\".  This field only applies to Services of types
+                            ClusterIP, NodePort, and LoadBalancer, and does apply
+                            to \"headless\" services. This field will be wiped when
+                            updating a Service to type ExternalName. \n This field
+                            may hold a maximum of two entries (dual-stack families,
+                            in either order).  These families must correspond to the
+                            values of the clusterIPs field, if specified. Both clusterIPs
+                            and ipFamilies are governed by the ipFamilyPolicy field."
                           items:
+                            description: IPFamily represents the IP Family (IPv4 or
+                              IPv6). This type is used to express the family of an
+                              IP expressed by a type (e.g. service.spec.ipFamilies).
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service. If there is no
+                            value provided, then this field will be set to SingleStack.
+                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail). The ipFamilies and clusterIPs fields depend on
+                            the value of this field. This field will be wiped when
+                            updating a service to type ExternalName.
                           type: string
                         loadBalancerClass:
+                          description: loadBalancerClass is the class of the load
+                            balancer implementation this Service belongs to. If specified,
+                            the value of this field must be a label-style identifier,
+                            with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                            Unprefixed names are reserved for end-users. This field
+                            can only be set when the Service type is 'LoadBalancer'.
+                            If not set, the default load balancer implementation is
+                            used, today this is typically done through the cloud provider
+                            integration, but should apply for any default implementation.
+                            If set, it is assumed that a load balancer implementation
+                            is watching for Services with a matching class. Any default
+                            load balancer implementation (e.g. cloud providers) should
+                            ignore Services that set this field. This field can only
+                            be set when creating or updating a Service to type 'LoadBalancer'.
+                            Once set, it can not be changed. This field will be wiped
+                            when a service is updated to a non 'LoadBalancer' type.
                           type: string
                         loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
                           type: string
                         loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
                           items:
                             type: string
                           type: array
                         ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                           items:
+                            description: ServicePort contains information on service's
+                              port.
                             properties:
                               appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol.
                                 type: string
                               name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
                                 type: string
                               nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type is NodePort or LoadBalancer.  Usually
+                                  assigned by the system. If a value is specified,
+                                  in-range, and not in use it will be used, otherwise
+                                  the operation will fail.  If not specified, a port
+                                  will be allocated if this Service requires one.  If
+                                  this field is specified when creating a Service
+                                  which does not need it, creation will fail. This
+                                  field will be wiped when updating a Service to no
+                                  longer need it (e.g. changing type from NodePort
+                                  to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
                                 format: int32
                                 type: integer
                               port:
+                                description: The port that will be exposed by this
+                                  service.
                                 format: int32
                                 type: integer
                               protocol:
                                 default: TCP
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
                                 type: string
                               targetPort:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
@@ -3882,53 +8625,143 @@ spec:
                           - protocol
                           x-kubernetes-list-type: map
                         publishNotReadyAddresses:
+                          description: publishNotReadyAddresses indicates that any
+                            agent which deals with endpoints for this Service should
+                            disregard any indications of ready/not-ready. The primary
+                            use case for setting this field is for a StatefulSet's
+                            Headless Service to propagate SRV DNS records for its
+                            Pods for the purpose of peer discovery. The Kubernetes
+                            controllers that generate Endpoints and EndpointSlice
+                            resources for Services interpret this to mean that all
+                            endpoints are considered "ready" even if the Pods themselves
+                            are not. Agents which consume only Kubernetes generated
+                            endpoints through the Endpoints or EndpointSlice resources
+                            can safely assume this behavior.
                           type: boolean
                         selector:
                           additionalProperties:
                             type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                           type: object
                           x-kubernetes-map-type: atomic
                         sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                           type: string
                         sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
                           properties:
                             clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
                               properties:
                                 timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
                                   format: int32
                                   type: integer
                               type: object
                           type: object
                         type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object or EndpointSlice objects. If clusterIP is "None",
+                            no virtual IP is allocated and the endpoints are published
+                            as a set of endpoints rather than a virtual IP. "NodePort"
+                            builds on ClusterIP and allocates a port on every node
+                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
+                            builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the
+                            same endpoints as the clusterIP. "ExternalName" aliases
+                            this service to the specified externalName. Several other
+                            fields do not apply to ExternalName services. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
                           type: string
                       type: object
                     status:
+                      description: 'Most recently observed status of the service.
+                        Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                       properties:
                         conditions:
+                          description: Current service state
                           items:
+                            description: "Condition contains details for one aspect
+                              of the current state of this API Resource. --- This
+                              struct is intended for direct use as an array at the
+                              field path .status.conditions.  For example, type FooStatus
+                              struct{ // Represents the observations of a foo's current
+                              state. // Known .status.conditions.type are: \"Available\",
+                              \"Progressing\", and \"Degraded\" // +patchMergeKey=type
+                              // +patchStrategy=merge // +listType=map // +listMapKey=type
+                              Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                              patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                              \n // other fields }"
                             properties:
                               lastTransitionTime:
+                                description: lastTransitionTime is the last time the
+                                  condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If
+                                  that is not known, then using the time when the
+                                  API field changed is acceptable.
                                 format: date-time
                                 type: string
                               message:
+                                description: message is a human readable message indicating
+                                  details about the transition. This may be an empty
+                                  string.
                                 maxLength: 32768
                                 type: string
                               observedGeneration:
+                                description: observedGeneration represents the .metadata.generation
+                                  that the condition was set based upon. For instance,
+                                  if .metadata.generation is currently 12, but the
+                                  .status.conditions[x].observedGeneration is 9, the
+                                  condition is out of date with respect to the current
+                                  state of the instance.
                                 format: int64
                                 minimum: 0
                                 type: integer
                               reason:
+                                description: reason contains a programmatic identifier
+                                  indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define
+                                  expected values and meanings for this field, and
+                                  whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string. This field
+                                  may not be empty.
                                 maxLength: 1024
                                 minLength: 1
                                 pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                                 type: string
                               status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
                                 enum:
                                 - "True"
                                 - "False"
                                 - Unknown
                                 type: string
                               type:
+                                description: type of condition in CamelCase or in
+                                  foo.example.com/CamelCase. --- Many .condition.type
+                                  values are consistent across resources like Available,
+                                  but because arbitrary conditions can be useful (see
+                                  .node.status.conditions), the ability to deconflict
+                                  is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                 maxLength: 316
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
@@ -3944,26 +8777,59 @@ spec:
                           - type
                           x-kubernetes-list-type: map
                         loadBalancer:
+                          description: LoadBalancer contains the current status of
+                            the load-balancer, if one is present.
                           properties:
                             ingress:
+                              description: Ingress is a list containing ingress points
+                                for the load-balancer. Traffic intended for the service
+                                should be sent to these ingress points.
                               items:
+                                description: 'LoadBalancerIngress represents the status
+                                  of a load-balancer ingress point: traffic intended
+                                  for the service should be sent to an ingress point.'
                                 properties:
                                   hostname:
+                                    description: Hostname is set for load-balancer
+                                      ingress points that are DNS based (typically
+                                      AWS load-balancers)
                                     type: string
                                   ip:
+                                    description: IP is set for load-balancer ingress
+                                      points that are IP based (typically GCE or OpenStack
+                                      load-balancers)
                                     type: string
                                   ports:
+                                    description: Ports is a list of records of service
+                                      ports If used, every port defined in the service
+                                      should have an entry in it
                                     items:
                                       properties:
                                         error:
+                                          description: 'Error is to record the problem
+                                            with the service port The format of the
+                                            error shall comply with the following
+                                            rules: - built-in error values shall be
+                                            specified in this file and those shall
+                                            use CamelCase names - cloud provider specific
+                                            error values must have names that comply
+                                            with the format foo.example.com/CamelCase.
+                                            --- The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
                                           maxLength: 316
                                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                           type: string
                                         port:
+                                          description: Port is the port number of
+                                            the service port of which status is recorded
+                                            here
                                           format: int32
                                           type: integer
                                         protocol:
                                           default: TCP
+                                          description: 'Protocol is the protocol of
+                                            the service port of which status is recorded
+                                            here The supported values are: "TCP",
+                                            "UDP", "SCTP"'
                                           type: string
                                       required:
                                       - port
@@ -3978,39 +8844,71 @@ spec:
                   type: object
                 type: array
               startScript:
+                description: 'Required: path to druid start script to be run on container
+                  start'
                 type: string
               startUpProbe:
+                description: 'Optional: StartupProbe for nodeSpec'
                 properties:
                   exec:
+                    description: Exec specifies the action to take.
                     properties:
                       command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
                         items:
                           type: string
                         type: array
                     type: object
                   failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
                     format: int32
                     type: integer
                   grpc:
+                    description: GRPC specifies an action involving a GRPC port. This
+                      is an alpha field and requires enabling GRPCContainerProbe feature
+                      gate.
                     properties:
                       port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
+                        description: "Service is the name of the service to place
+                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                          \n If this is not specified, the default behavior is defined
+                          by gRPC."
                         type: string
                     required:
                     - port
                     type: object
                   httpGet:
+                    description: HTTPGet specifies the http request to perform.
                     properties:
                       host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
+                              description: The header field name
                               type: string
                             value:
+                              description: The header field value
                               type: string
                           required:
                           - name
@@ -4018,129 +8916,242 @@ spec:
                           type: object
                         type: array
                       path:
+                        description: Path to access on the HTTP server.
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                       scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
                         type: string
                     required:
                     - port
                     type: object
                   initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
                   periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
                     format: int32
                     type: integer
                   successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
                     format: int32
                     type: integer
                   tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
                     properties:
                       host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                     required:
                     - port
                     type: object
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure. The grace period is the duration
+                      in seconds after the processes running in the pod are sent a
+                      termination signal and the time when the processes are forcibly
+                      halted with a kill signal. Set this value longer than the expected
+                      cleanup time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec. Value must
+                      be non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). This is a
+                      beta field and requires enabling ProbeTerminationGracePeriod
+                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                      is used if unset.
                     format: int64
                     type: integer
                   timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
                 type: object
               tolerations:
+                description: 'Optional: toleration to be used in order to run Druid
+                  on nodes tainted'
                 items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
                   properties:
                     effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
                       type: string
                     operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
                       format: int64
                       type: integer
                     value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               updateStrategy:
+                description: Optional
                 properties:
                   rollingUpdate:
+                    description: RollingUpdate is used to communicate parameters when
+                      Type is RollingUpdateStatefulSetStrategyType.
                     properties:
                       partition:
+                        description: Partition indicates the ordinal at which the
+                          StatefulSet should be partitioned. Default value is 0.
                         format: int32
                         type: integer
                     type: object
                   type:
+                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                      Default is RollingUpdate.
                     type: string
                 type: object
               volumeClaimTemplates:
+                description: 'Optional: volumes etc for the Druid pods'
                 items:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
                   properties:
                     apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                       type: string
                     kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                       type: string
                     metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        finalizers:
-                          items:
-                            type: string
-                          type: array
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        name:
-                          type: string
-                        namespace:
-                          type: string
+                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                       type: object
                     spec:
+                      description: 'Spec defines the desired characteristics of a
+                        volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                           items:
                             type: string
                           type: array
                         dataSource:
+                          description: 'This field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            * An existing PVC (PersistentVolumeClaim) If the provisioner
+                            or an external controller can support the specified data
+                            source, it will create a new volume based on the contents
+                            of the specified data source. If the AnyVolumeDataSource
+                            feature gate is enabled, this field will always have the
+                            same contents as the DataSourceRef field.'
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                           required:
                           - kind
                           - name
                           type: object
+                          x-kubernetes-map-type: atomic
                         dataSourceRef:
+                          description: 'Specifies the object from which to populate
+                            the volume with data, if a non-empty volume is desired.
+                            This may be any local object from a non-empty API group
+                            (non core object) or a PersistentVolumeClaim object. When
+                            this field is specified, volume binding will only succeed
+                            if the type of the specified object matches some installed
+                            volume populator or dynamic provisioner. This field will
+                            replace the functionality of the DataSource field and
+                            as such if both fields are non-empty, they must have the
+                            same value. For backwards compatibility, both fields (DataSource
+                            and DataSourceRef) will be set to the same value automatically
+                            if one of them is empty and the other is non-empty. There
+                            are two important differences between DataSource and DataSourceRef:
+                            * While DataSource only allows two specific types of objects,
+                            DataSourceRef allows any non-core object, as well as PersistentVolumeClaim
+                            objects. * While DataSource ignores disallowed values
+                            (dropping them), DataSourceRef preserves all values, and
+                            generates an error if a disallowed value is specified.
+                            (Alpha) Using this field requires the AnyVolumeDataSource
+                            feature gate to be enabled.'
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                           required:
                           - kind
                           - name
                           type: object
+                          x-kubernetes-map-type: atomic
                         resources:
+                          description: 'Resources represents the minimum resources
+                            the volume should have. If RecoverVolumeExpansionFailure
+                            feature is enabled users are allowed to specify resource
+                            requirements that are lower than previous value but must
+                            still be higher than capacity recorded in the status field
+                            of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                           properties:
                             limits:
                               additionalProperties:
@@ -4149,6 +9160,8 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                             requests:
                               additionalProperties:
@@ -4157,18 +9170,41 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         selector:
+                          description: A label query over volumes to consider for
+                            binding.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -4180,18 +9216,35 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
                         volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec.
                           type: string
                         volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
                           type: string
                       type: object
                     status:
+                      description: 'Status represents the current information/status
+                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                           items:
                             type: string
                           type: array
@@ -4202,6 +9255,18 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: The storage resource within AllocatedResources
+                            tracks the capacity allocated to a PVC. It may be larger
+                            than the actual capacity when a volume expansion operation
+                            is requested. For storage quota, the larger value from
+                            allocatedResources and PVC.spec.resources is used. If
+                            allocatedResources is not set, PVC.spec.resources alone
+                            is used for quota calculation. If a volume expansion capacity
+                            request is lowered, allocatedResources is only lowered
+                            if there are no expansion operations in progress and if
+                            the actual volume capacity is equal or lower than the
+                            requested capacity. This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature.
                           type: object
                         capacity:
                           additionalProperties:
@@ -4210,23 +9275,42 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Represents the actual resources of the underlying
+                            volume.
                           type: object
                         conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
                           items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
                             properties:
                               lastProbeTime:
+                                description: Last time we probed the condition.
                                 format: date-time
                                 type: string
                               lastTransitionTime:
+                                description: Last time the condition transitioned
+                                  from one status to another.
                                 format: date-time
                                 type: string
                               message:
+                                description: Human-readable message indicating details
+                                  about last transition.
                                 type: string
                               reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
                                 type: string
                               status:
                                 type: string
                               type:
+                                description: PersistentVolumeClaimConditionType is
+                                  a valid value of PersistentVolumeClaimCondition.Type
                                 type: string
                             required:
                             - status
@@ -4234,26 +9318,50 @@ spec:
                             type: object
                           type: array
                         phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
                           type: string
                         resizeStatus:
+                          description: ResizeStatus stores status of resize operation.
+                            ResizeStatus is not set by default but when expansion
+                            is complete resizeStatus is set to empty string by resize
+                            controller or kubelet. This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature.
                           type: string
                       type: object
                   type: object
                 type: array
               volumeMounts:
                 items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
                   properties:
                     mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
                       type: string
                     mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
                       type: string
                     name:
+                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
                       type: boolean
                     subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted. Behaves similarly to
+                        SubPath but environment variable references $(VAR_NAME) are
+                        expanded using the container's environment. Defaults to ""
+                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
                       type: string
                   required:
                   - mountPath
@@ -4262,103 +9370,216 @@ spec:
                 type: array
               volumes:
                 items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
+                      description: 'AWSElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                       properties:
                         fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
                           type: string
                         partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).'
                           format: int32
                           type: integer
                         readOnly:
+                          description: 'Specify "true" to force and set the ReadOnly
+                            property in VolumeMounts to "true". If omitted, the default
+                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: boolean
                         volumeID:
+                          description: 'Unique ID of the persistent disk resource
+                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
+                      description: AzureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
+                          description: 'Host Caching mode: None, Read Only, Read Write.'
                           type: string
                         diskName:
+                          description: The Name of the data disk in the blob storage
                           type: string
                         diskURI:
+                          description: The URI the data disk in the blob storage
                           type: string
                         fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
+                          description: 'Expected values Shared: multiple blob disks
+                            per storage account  Dedicated: single blob disk per storage
+                            account  Managed: azure managed data disk (only in managed
+                            availability set). defaults to shared'
                           type: string
                         readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
+                      description: AzureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
+                          description: the name of secret that contains Azure Storage
+                            Account Name and Key
                           type: string
                         shareName:
+                          description: Share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
+                      description: CephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
                       properties:
                         monitors:
+                          description: 'Required: Monitors is a collection of Ceph
+                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         path:
+                          description: 'Optional: Used as the mounted root, rather
+                            than the full Ceph tree, default is /'
                           type: string
                         readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: boolean
                         secretFile:
+                          description: 'Optional: SecretFile is the path to key ring
+                            for User, default is /etc/ceph/user.secret More info:
+                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                         secretRef:
+                          description: 'Optional: SecretRef is reference to the authentication
+                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         user:
+                          description: 'Optional: User is the rados user name, default
+                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
+                      description: 'Cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                       properties:
                         fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                         readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: boolean
                         secretRef:
+                          description: 'Optional: points to a secret object containing
+                            parameters used to connect to OpenStack.'
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         volumeID:
+                          description: 'volume id used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
+                      description: ConfigMap represents a configMap that should populate
+                        this volume
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits used to set permissions
+                            on created files by default. Must be an octal value between
+                            0000 and 0777 or a decimal value between 0 and 511. YAML
+                            accepts both octal and decimal values, JSON requires decimal
+                            values for mode bits. Defaults to 0644. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.'
                           format: int32
                           type: integer
                         items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: The key to project.
                                 type: string
                               mode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file. Must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -4366,137 +9587,314 @@ spec:
                             type: object
                           type: array
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
+                          description: Specify whether the ConfigMap or its keys must
+                            be defined
                           type: boolean
                       type: object
+                      x-kubernetes-map-type: atomic
                     csi:
+                      description: CSI (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers (Beta
+                        feature).
                       properties:
                         driver:
+                          description: Driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
                           type: string
                         fsType:
+                          description: Filesystem type to mount. Ex. "ext4", "xfs",
+                            "ntfs". If not provided, the empty value is passed to
+                            the associated CSI driver which will determine the default
+                            filesystem to apply.
                           type: string
                         nodePublishSecretRef:
+                          description: NodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         readOnly:
+                          description: Specifies a read-only configuration for the
+                            volume. Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
+                          description: VolumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
+                      description: DownwardAPI represents downward API about the pod
+                        that should populate this volume
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a Optional: mode bits used to set
+                            permissions on created files by default. Must be an octal
+                            value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
+                          description: Items is a list of downward API volume file
                           items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
                             properties:
                               fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                               mode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file, must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
                                 type: string
                               resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                             - path
                             type: object
                           type: array
                       type: object
                     emptyDir:
+                      description: 'EmptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       properties:
                         medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
+                      description: "Ephemeral represents a volume that is handled
+                        by a cluster storage driver. The volume's lifecycle is tied
+                        to the pod that defines it - it will be created before the
+                        pod starts, and deleted when the pod is removed. \n Use this
+                        if: a) the volume is only needed while the pod runs, b) features
+                        of normal volumes like restoring from snapshot or capacity
+                        tracking are needed, c) the storage driver is specified through
+                        a storage class, and d) the storage driver supports dynamic
+                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
+                        for more information on the connection between this volume
+                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                        or one of the vendor-specific APIs for volumes that persist
+                        for longer than the lifecycle of an individual pod. \n Use
+                        CSI for light-weight local ephemeral volumes if the CSI driver
+                        is meant to be used that way - see the documentation of the
+                        driver for more information. \n A pod can use both types of
+                        ephemeral volumes and persistent volumes at the same time."
                       properties:
                         volumeClaimTemplate:
+                          description: "Will be used to create a stand-alone PVC to
+                            provision the volume. The pod in which this EphemeralVolumeSource
+                            is embedded will be the owner of the PVC, i.e. the PVC
+                            will be deleted together with the pod.  The name of the
+                            PVC will be `<pod name>-<volume name>` where `<volume
+                            name>` is the name from the `PodSpec.Volumes` array entry.
+                            Pod validation will reject the pod if the concatenated
+                            name is not valid for a PVC (for example, too long). \n
+                            An existing PVC with that name that is not owned by the
+                            pod will *not* be used for the pod to avoid using an unrelated
+                            volume by mistake. Starting the pod is then blocked until
+                            the unrelated PVC is removed. If such a pre-created PVC
+                            is meant to be used by the pod, the PVC has to updated
+                            with an owner reference to the pod once the pod exists.
+                            Normally this should not be necessary, but it may be useful
+                            when manually reconstructing a broken cluster. \n This
+                            field is read-only and no changes will be made by Kubernetes
+                            to the PVC after it has been created. \n Required, must
+                            not be nil."
                           properties:
                             metadata:
-                              properties:
-                                annotations:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                finalizers:
-                                  items:
-                                    type: string
-                                  type: array
-                                labels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                name:
-                                  type: string
-                                namespace:
-                                  type: string
+                              description: May contain labels and annotations that
+                                will be copied into the PVC when creating it. No other
+                                fields are allowed and will be rejected during validation.
                               type: object
                             spec:
+                              description: The specification for the PersistentVolumeClaim.
+                                The entire content is copied unchanged into the PVC
+                                that gets created from this template. The same fields
+                                as in a PersistentVolumeClaim are also valid here.
                               properties:
                                 accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
+                                  description: 'This field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim) If the
+                                    provisioner or an external controller can support
+                                    the specified data source, it will create a new
+                                    volume based on the contents of the specified
+                                    data source. If the AnyVolumeDataSource feature
+                                    gate is enabled, this field will always have the
+                                    same contents as the DataSourceRef field.'
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
+                                  description: 'Specifies the object from which to
+                                    populate the volume with data, if a non-empty
+                                    volume is desired. This may be any local object
+                                    from a non-empty API group (non core object) or
+                                    a PersistentVolumeClaim object. When this field
+                                    is specified, volume binding will only succeed
+                                    if the type of the specified object matches some
+                                    installed volume populator or dynamic provisioner.
+                                    This field will replace the functionality of the
+                                    DataSource field and as such if both fields are
+                                    non-empty, they must have the same value. For
+                                    backwards compatibility, both fields (DataSource
+                                    and DataSourceRef) will be set to the same value
+                                    automatically if one of them is empty and the
+                                    other is non-empty. There are two important differences
+                                    between DataSource and DataSourceRef: * While
+                                    DataSource only allows two specific types of objects,
+                                    DataSourceRef allows any non-core object, as well
+                                    as PersistentVolumeClaim objects. * While DataSource
+                                    ignores disallowed values (dropping them), DataSourceRef
+                                    preserves all values, and generates an error if
+                                    a disallowed value is specified. (Alpha) Using
+                                    this field requires the AnyVolumeDataSource feature
+                                    gate to be enabled.'
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. If RecoverVolumeExpansionFailure
+                                    feature is enabled users are allowed to specify
+                                    resource requirements that are lower than previous
+                                    value but must still be higher than capacity recorded
+                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -4505,6 +9903,8 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -4513,18 +9913,46 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                   type: object
                                 selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -4536,13 +9964,27 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 storageClassName:
+                                  description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
                                 volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem
+                                    is implied when not included in claim spec.
                                   type: string
                                 volumeName:
+                                  description: VolumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -4550,125 +9992,252 @@ spec:
                           type: object
                       type: object
                     fc:
+                      description: FC represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
                       properties:
                         fsType:
+                          description: 'Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
                           type: string
                         lun:
+                          description: 'Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         targetWWNs:
+                          description: 'Optional: FC target worldwide names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
+                          description: 'Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
+                      description: FlexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
                       properties:
                         driver:
+                          description: Driver is the name of the driver to use for
+                            this volume.
                           type: string
                         fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". The default filesystem depends on FlexVolume
+                            script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
+                          description: 'Optional: Extra command options if any.'
                           type: object
                         readOnly:
+                          description: 'Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         secretRef:
+                          description: 'Optional: SecretRef is reference to the secret
+                            object containing sensitive information to pass to the
+                            plugin scripts. This may be empty if no secret object
+                            is specified. If the secret object contains more than
+                            one secret, all secrets are passed to the plugin scripts.'
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                       required:
                       - driver
                       type: object
                     flocker:
+                      description: Flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
                       properties:
                         datasetName:
+                          description: Name of the dataset stored as metadata -> name
+                            on the dataset for Flocker should be considered as deprecated
                           type: string
                         datasetUUID:
+                          description: UUID of the dataset. This is unique identifier
+                            of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
+                      description: 'GCEPersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                       properties:
                         fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
                           type: string
                         partition:
+                          description: 'The partition in the volume that you want
+                            to mount. If omitted, the default is to mount by volume
+                            name. Examples: For volume /dev/sda1, you specify the
+                            partition as "1". Similarly, the volume partition for
+                            /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           format: int32
                           type: integer
                         pdName:
+                          description: 'Unique name of the PD resource in GCE. Used
+                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: string
                         readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
+                      description: 'GitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
                       properties:
                         directory:
+                          description: Target directory name. Must not contain or
+                            start with '..'.  If '.' is supplied, the volume directory
+                            will be the git repository.  Otherwise, if specified,
+                            the volume will contain the git repository in the subdirectory
+                            with the given name.
                           type: string
                         repository:
+                          description: Repository URL
                           type: string
                         revision:
+                          description: Commit hash for the specified revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
+                      description: 'Glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                       properties:
                         endpoints:
+                          description: 'EndpointsName is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         path:
+                          description: 'Path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         readOnly:
+                          description: 'ReadOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
+                      description: 'HostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
                       properties:
                         path:
+                          description: 'Path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                         type:
+                          description: 'Type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
+                      description: 'ISCSI represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                       properties:
                         chapAuthDiscovery:
+                          description: whether support iSCSI Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
+                          description: whether support iSCSI Session CHAP authentication
                           type: boolean
                         fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
                           type: string
                         initiatorName:
+                          description: Custom iSCSI Initiator Name. If initiatorName
+                            is specified with iscsiInterface simultaneously, new iSCSI
+                            interface <target portal>:<volume name> will be created
+                            for the connection.
                           type: string
                         iqn:
+                          description: Target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
+                          description: iSCSI Interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
                           type: string
                         lun:
+                          description: iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
+                          description: iSCSI Target Portal List. The portal is either
+                            an IP or ip_addr:port if the port is other than default
+                            (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
+                          description: ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
                           type: boolean
                         secretRef:
+                          description: CHAP Secret for iSCSI target and initiator
+                            authentication
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         targetPortal:
+                          description: iSCSI Target Portal. The Portal is either an
+                            IP or ip_addr:port if the port is other than default (typically
+                            TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -4676,67 +10245,146 @@ spec:
                       - targetPortal
                       type: object
                     name:
+                      description: 'Volume''s name. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     nfs:
+                      description: 'NFS represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                       properties:
                         path:
+                          description: 'Path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                         readOnly:
+                          description: 'ReadOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: boolean
                         server:
+                          description: 'Server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
+                      description: 'PersistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
+                      description: PhotonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
+                          description: ID that identifies Photon Controller persistent
+                            disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
+                      description: PortworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
                       properties:
                         fsType:
+                          description: FSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
                           type: string
                         readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
+                          description: VolumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
+                      description: Items for all in one resources secrets, configmaps,
+                        and downward API
                       properties:
                         defaultMode:
+                          description: Mode bits used to set permissions on created
+                            files by default. Must be an octal value between 0000
+                            and 0777 or a decimal value between 0 and 511. YAML accepts
+                            both octal and decimal values, JSON requires decimal values
+                            for mode bits. Directories within the path are not affected
+                            by this setting. This might be in conflict with other
+                            options that affect the file mode, like fsGroup, and the
+                            result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
+                          description: list of volume projections
                           items:
+                            description: Projection that may be projected along with
+                              other supported volume types
                             properties:
                               configMap:
+                                description: information about the configMap data
+                                  to project
                                 properties:
                                   items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: The key to project.
                                           type: string
                                         mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file. Must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4744,60 +10392,143 @@ spec:
                                       type: object
                                     type: array
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its keys must be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               downwardAPI:
+                                description: information about the downwardAPI data
+                                  to project
                                 properties:
                                   items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
                                     items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
                                       properties:
                                         fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                       - path
                                       type: object
                                     type: array
                                 type: object
                               secret:
+                                description: information about the secret data to
+                                  project
                                 properties:
                                   items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose
+                                      name is the key and content is the value. If
+                                      specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: The key to project.
                                           type: string
                                         mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file. Must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element
+                                            '..'. May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4805,18 +10536,45 @@ spec:
                                       type: object
                                     type: array
                                   name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               serviceAccountToken:
+                                description: information about the serviceAccountToken
+                                  data to project
                                 properties:
                                   audience:
+                                    description: Audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
                                     type: string
                                   expirationSeconds:
+                                    description: ExpirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
+                                    description: Path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
                                     type: string
                                 required:
                                 - path
@@ -4825,74 +10583,145 @@ spec:
                           type: array
                       type: object
                     quobyte:
+                      description: Quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
                       properties:
                         group:
+                          description: Group to map volume access to Default is no
+                            group
                           type: string
                         readOnly:
+                          description: ReadOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
                           type: boolean
                         registry:
+                          description: Registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
                           type: string
                         tenant:
+                          description: Tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
                           type: string
                         user:
+                          description: User to map volume access to Defaults to serivceaccount
+                            user
                           type: string
                         volume:
+                          description: Volume is a string that references an already
+                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
+                      description: 'RBD represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
                         fsType:
+                          description: 'Filesystem type of the volume that you want
+                            to mount. Tip: Ensure that the filesystem type is supported
+                            by the host operating system. Examples: "ext4", "xfs",
+                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
                           type: string
                         image:
+                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         keyring:
+                          description: 'Keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         monitors:
+                          description: 'A collection of Ceph monitors. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         pool:
+                          description: 'The rados pool name. Default is rbd. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         readOnly:
+                          description: 'ReadOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: boolean
                         secretRef:
+                          description: 'SecretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         user:
+                          description: 'The rados user name. Default is admin. More
+                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
+                      description: ScaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Default is "xfs".
                           type: string
                         gateway:
+                          description: The host address of the ScaleIO API Gateway.
                           type: string
                         protectionDomain:
+                          description: The name of the ScaleIO Protection Domain for
+                            the configured storage.
                           type: string
                         readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: SecretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         sslEnabled:
+                          description: Flag to enable/disable SSL communication with
+                            Gateway, default false
                           type: boolean
                         storageMode:
+                          description: Indicates whether the storage for a volume
+                            should be ThickProvisioned or ThinProvisioned. Default
+                            is ThinProvisioned.
                           type: string
                         storagePool:
+                          description: The ScaleIO Storage Pool associated with the
+                            protection domain.
                           type: string
                         system:
+                          description: The name of the storage system as configured
+                            in ScaleIO.
                           type: string
                         volumeName:
+                          description: The name of a volume already created in the
+                            ScaleIO system that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4900,19 +10729,54 @@ spec:
                       - system
                       type: object
                     secret:
+                      description: 'Secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits used to set permissions
+                            on created files by default. Must be an octal value between
+                            0000 and 0777 or a decimal value between 0 and 511. YAML
+                            accepts both octal and decimal values, JSON requires decimal
+                            values for mode bits. Defaults to 0644. Directories within
+                            the path are not affected by this setting. This might
+                            be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits
+                            set.'
                           format: int32
                           type: integer
                         items:
+                          description: If unspecified, each key-value pair in the
+                            Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: The key to project.
                                 type: string
                               mode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file. Must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -4920,35 +10784,73 @@ spec:
                             type: object
                           type: array
                         optional:
+                          description: Specify whether the Secret or its keys must
+                            be defined
                           type: boolean
                         secretName:
+                          description: 'Name of the secret in the pod''s namespace
+                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     storageos:
+                      description: StorageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
+                          description: Defaults to false (read/write). ReadOnly here
+                            will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: SecretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
                           properties:
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         volumeName:
+                          description: VolumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
                           type: string
                         volumeNamespace:
+                          description: VolumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
+                      description: VsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
                       properties:
                         fsType:
+                          description: Filesystem type to mount. Must be a filesystem
+                            type supported by the host operating system. Ex. "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
+                          description: Storage Policy Based Management (SPBM) profile
+                            ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
+                          description: Storage Policy Based Management (SPBM) profile
+                            name.
                           type: string
                         volumePath:
+                          description: Path that identifies vSphere volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4958,8 +10860,13 @@ spec:
                   type: object
                 type: array
               zookeeper:
+                description: futuristic stuff to make Druid dependency setup extensible
+                  from within Druid operator ignore for now.
                 properties:
                   spec:
+                    description: RawMessage is a raw encoded JSON value. It implements
+                      Marshaler and Unmarshaler and can be used to delay JSON decoding
+                      or precompute a JSON encoding.
                     format: byte
                     type: string
                   type:
@@ -4975,6 +10882,7 @@ spec:
             - startScript
             type: object
           status:
+            description: DruidStatus defines the observed state of Druid
             properties:
               configMaps:
                 items:
@@ -4985,6 +10893,9 @@ spec:
                   type: string
                 type: array
               druidNodeStatus:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
                 properties:
                   druidNode:
                     type: string
@@ -5031,11 +10942,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
-{{- end }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/druid-io/druid-operator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #312 .

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

- Run tests in CI.
- With the update makefile, we are maintaining kubebuilder version in makefile. Having them in dockerfile is not needed.
- Add more build steps and job to CI. 
- Controller gen version update. 
- Update CRD defination in helm too in makefile

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `github/workflows`
 * `Dockerfile`
