### PR TITLE
docs: update examples documentation to use of loading from ENV

### DIFF
--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -64,6 +64,8 @@ spec:
     druid.metadata.storage.connector.host=localhost
     druid.metadata.storage.connector.port=1527
     druid.metadata.storage.connector.createTables=true
+    # alternatively, you can load from the environment variable using the following
+    # druid.metadata.storage.connector.connectURI={"type":"environment","variable":"CONNECTOR_URI"}
 
     # Deep Storage
     druid.storage.type=local
@@ -334,7 +336,7 @@ spec:
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
-          
+
     routers:
       nodeType: "router"
       druid.port: 8088
@@ -354,7 +356,7 @@ spec:
         druid.router.coordinatorServiceName=druid/coordinator
 
         # Management proxy to coordinator / overlord: required for unified web console.
-        druid.router.managementProxy.enabled=true       
+        druid.router.managementProxy.enabled=true
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M


### PR DESCRIPTION
### Description

This PR enhances the Druid Operator's documentation to improve clarity. It addresses the following:

* **Introduction of Environment Variables in Druid Configuration:**  A new section in the examples documentation introduces the use of environment variables within `common.runtime.properties`. This provides a mechanism for greater configuration flexibility and security. Users can now manage sensitive information or environment-specific values externally, without directly embedding them in the Druid configuration. This was already being used on https://github.com/druid-io/druid-operator/issues/35#issuecomment-606562407

* **Practical Example of Environment Variables:** A concrete example showcasing the utilization of environment variables for the metadata store configuration (`druid.metadata.storage.connector.*`) is added. This example guides users on how to implement this new feature effectively. 
 
<hr>

##### Key changed/added files in this PR

* `docs/examples.md`